### PR TITLE
Updated PR build to use GitHub action service container

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -97,6 +97,23 @@ jobs:
   test-app:
     runs-on: ubuntu-22.04-arm
     if: ${{ !github.event.pull_request.draft }}
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: workflow_manager
+          POSTGRES_USER: orcabus
+          POSTGRES_PASSWORD: orcabus # pragma: allowlist secret
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/app/Makefile
+++ b/app/Makefile
@@ -18,8 +18,8 @@ lint:
 lint-fix:
 	@black -t py312 . --exclude .venv
 
-# full mock suite test pipeline - install deps, bring up compose stack, run suite, bring down compose stack
-test: install up suite down
+# alias to test suite
+test: suite
 
 suite:
 	@python manage.py test


### PR DESCRIPTION
* Theory is to avoid image pull rate limit by leveraging
  GitHub built-in service for image cache.
