### PR TITLE
Implemented handle_wrsc_event for handling new WRSC event schema

### DIFF
--- a/app/workflow_manager_proc/lambdas/handle_wrsc_event.py
+++ b/app/workflow_manager_proc/lambdas/handle_wrsc_event.py
@@ -1,0 +1,32 @@
+import django
+
+django.setup()
+
+# --- keep ^^^ at top of the module
+import logging
+
+from workflow_manager_proc.domain.event import wrsc
+from workflow_manager_proc.services import workflow_run
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def handler(event, context):
+    """
+    Parameters:
+        event: JSON event conform to WorkflowRunStateChange
+        context: ignored for now (only used to conform to Lambda handler conventions)
+    Procedure:
+        - Unpack AWS event
+        - create new State for WorkflowRun if required
+        - relay the state change as WorkflowManager WRSC event if applicable
+    """
+    logger.info(f"Processing {event}, {context}")
+
+    input_wrsc_with_envelope = wrsc.AWSEvent.model_validate(event)
+    input_wrsc: wrsc.WorkflowRunStateChange = input_wrsc_with_envelope.detail
+
+    workflow_run.create_workflow_run(input_wrsc)
+
+    logger.info(f"{__name__} done.")

--- a/app/workflow_manager_proc/tests/test_handle_wrsc_event.py
+++ b/app/workflow_manager_proc/tests/test_handle_wrsc_event.py
@@ -1,0 +1,68 @@
+import os
+from unittest import mock
+
+from pydantic import ValidationError
+
+from workflow_manager.models import WorkflowRun, Workflow, Library, LibraryAssociation, State, Payload
+from workflow_manager_proc.lambdas import handle_wrsc_event
+from workflow_manager_proc.tests.case import WorkflowManagerProcUnitTestCase, logger
+
+
+class WrscEventHandlerUnitTests(WorkflowManagerProcUnitTestCase):
+
+    def setUp(self) -> None:
+        self.env_mock = mock.patch.dict(os.environ, {"EVENT_BUS_NAME": "FooBus"})
+        self.env_mock.start()
+        super().setUp()
+
+    def tearDown(self) -> None:
+        self.env_mock.stop()
+        super().tearDown()
+
+    def test_handle_wrsc_event_with_legacy_schema(self):
+        """
+        python manage.py test workflow_manager_proc.tests.test_handle_wrsc_event.WrscEventHandlerUnitTests.test_handle_wrsc_event_with_legacy_schema
+        """
+        self.load_mock_wrsc_legacy()
+
+        try:
+
+            handle_wrsc_event.handler(self.mock_wrsc_legacy, None)
+
+        except ValidationError as e:
+            logger.exception(f"THIS ERROR EXCEPTION IS INTENTIONAL FOR TEST. NOT ACTUAL ERROR. \n{e}")
+
+        self.assertRaises(ValidationError)
+        self.assertEqual(Workflow.objects.count(), 0)
+        self.assertEqual(WorkflowRun.objects.count(), 0)
+        self.assertEqual(Library.objects.count(), 0)
+
+    def test_handle_wrsc_event(self):
+        """
+        python manage.py test workflow_manager_proc.tests.test_handle_wrsc_event.WrscEventHandlerUnitTests.test_handle_wrsc_event
+        """
+        self.load_mock_wrsc_max()
+
+        handle_wrsc_event.handler(self.event, None)
+
+        self.assertEqual(Workflow.objects.count(), 1)
+        self.assertEqual(WorkflowRun.objects.count(), 1)
+        self.assertEqual(State.objects.count(), 1)
+        self.assertEqual(Payload.objects.count(), 1)
+        self.assertEqual(Library.objects.count(), 2)
+        self.assertEqual(LibraryAssociation.objects.count(), 2)
+
+    def test_handle_wrsc_event_min(self):
+        """
+        python manage.py test workflow_manager_proc.tests.test_handle_wrsc_event.WrscEventHandlerUnitTests.test_handle_wrsc_event_min
+        """
+        self.load_mock_wrsc_min()
+
+        handle_wrsc_event.handler(self.event, None)
+
+        self.assertEqual(Workflow.objects.count(), 1)
+        self.assertEqual(WorkflowRun.objects.count(), 1)
+        self.assertEqual(State.objects.count(), 1)
+        self.assertEqual(Payload.objects.count(), 0)
+        self.assertEqual(Library.objects.count(), 0)
+        self.assertEqual(LibraryAssociation.objects.count(), 0)


### PR DESCRIPTION
* Added EventBridge routing rule on checking `id` and `workflow` fields
  present. Forward to the new WRSC event Lambda handler.
* Improved unit testing and beef up testing coverage throughout
      "the return of the Mockito"
