### PR TITLE
Fixed naive datetime warning for tz aware ORM DateTimeField

### DIFF
--- a/app/workflow_manager_proc/services/analysis_run.py
+++ b/app/workflow_manager_proc/services/analysis_run.py
@@ -1,10 +1,10 @@
 import logging
 import os
-import datetime
 import hashlib
 
 from django.db import transaction
 from django.db.models.query import QuerySet
+from django.utils import timezone
 
 from workflow_manager.models.analysis_context import ContextUseCase
 from workflow_manager.models.analysis_run_state import AnalysisRunState
@@ -75,7 +75,7 @@ def _create_analysis_run(event: ari.AnalysisRunInitiated)-> AnalysisRun:
         AnalysisRunState(
             analysis_run=analysis_run,
             status=Status.DRAFT.convention,
-            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
+            timestamp=timezone.now(),
         ).save()
 
         # attach the libraries associated with the AnalysisRunInitiated
@@ -210,7 +210,7 @@ def _finalise_analysis_run(event: arf.AnalysisRunFinalised) -> AnalysisRun:
     AnalysisRunState(
         analysis_run=analysis_run_db,
         status=Status.READY.convention,
-        timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
+        timestamp=timezone.now(),
     ).save()
     analysis_run_db.save()
     return analysis_run_db

--- a/app/workflow_manager_proc/services/workflow_run.py
+++ b/app/workflow_manager_proc/services/workflow_run.py
@@ -1,10 +1,10 @@
-import datetime
 import hashlib
 import logging
 import os
 import uuid
 
 from django.db import transaction
+from django.utils import timezone
 
 from workflow_manager.models import (
     WorkflowRun,
@@ -151,7 +151,7 @@ def establish_workflow_run_libraries(event: wrsc.WorkflowRunStateChange, wfr: Wo
         LibraryAssociation.objects.create(
             workflow_run=wfr,
             library=db_lib,
-            association_date=datetime.datetime.now(),
+            association_date=timezone.now(),
             status=ASSOCIATION_STATUS,
         )
 

--- a/app/workflow_manager_proc/services/workflow_run_legacy.py
+++ b/app/workflow_manager_proc/services/workflow_run_legacy.py
@@ -4,11 +4,11 @@ Deprecation note:
     This is retained here for backwards compatibility by Stacky execution engine.
     Most of this module impl is superseded by `workflow_run.py` with the newer WRSC event schema.
 """
-import datetime
 import logging
 import uuid
 
 from django.db import transaction
+from django.utils import timezone
 
 import workflow_manager.aws_event_bridge.executionservice.workflowrunstatechange as srv
 from workflow_manager.models import (
@@ -121,7 +121,7 @@ def _create_workflow_run(event: srv.WorkflowRunStateChange):
                 LibraryAssociation.objects.create(
                     workflow_run=wfr,
                     library=db_lib,
-                    association_date=datetime.datetime.now(),
+                    association_date=timezone.now(),
                     status=ASSOCIATION_STATUS,
                 )
 

--- a/app/workflow_manager_proc/tests/test_analysis_run.py
+++ b/app/workflow_manager_proc/tests/test_analysis_run.py
@@ -3,6 +3,8 @@ import os
 import time
 from unittest import mock
 
+from django.utils.timezone import make_aware
+
 from workflow_manager.models import Library, Status, AnalysisContext, AnalysisRunState
 from workflow_manager.models.analysis import Analysis
 from workflow_manager.models.analysis_context import ContextUseCase
@@ -85,7 +87,7 @@ class AnalysisRunUnitTests(WorkflowManagerProcUnitTestCase):
         AnalysisRunState(
             analysis_run=analysis_run,
             status=Status.DRAFT.convention,
-            timestamp=datetime.datetime.strptime("01/05/2025 6:00", "%m/%d/%Y %H:%M")
+            timestamp=make_aware(datetime.datetime.strptime("01/05/2025 6:00", "%m/%d/%Y %H:%M"))
         ).save()
 
     def clean_base_entities(self) -> None:


### PR DESCRIPTION
* Replaced and leveraged Framework supported `make_aware()` or `now()`
  django.utils.timezone module.
