### PR TITLE
Improved Analysis and AnalysisContext API endpoints

### DIFF
--- a/app/workflow_manager/serializers/analysis.py
+++ b/app/workflow_manager/serializers/analysis.py
@@ -1,5 +1,9 @@
+from rest_framework import serializers
+
+from workflow_manager.models import Analysis, AnalysisContext, Workflow
+from workflow_manager.serializers.analysis_context import AnalysisContextSerializer
 from workflow_manager.serializers.base import SerializersBase, OptionalFieldsMixin, OrcabusIdSerializerMetaMixin
-from workflow_manager.models import Analysis, Workflow, AnalysisContext
+from workflow_manager.serializers.workflow import WorkflowSerializer
 
 
 class AnalysisBaseSerializer(SerializersBase):
@@ -15,33 +19,70 @@ class AnalysisListParamSerializer(OptionalFieldsMixin, AnalysisBaseSerializer):
 class AnalysisMinSerializer(AnalysisBaseSerializer):
     class Meta(OrcabusIdSerializerMetaMixin):
         model = Analysis
-        fields = ["orcabus_id", "analysis_name", "analysis_version", 'status']
+        fields = ["orcabus_id", "analysis_name", "analysis_version", "status"]
 
 
 class AnalysisSerializer(AnalysisBaseSerializer):
     """
     Serializer to define a default representation of an Analysis record,
-    mainly used in record listings.
+    mainly used in record listing and retrieval views.
     """
-
-    class Meta(OrcabusIdSerializerMetaMixin):
-        model = Analysis
-        fields = "__all__"
-        # exclude = ["contexts", "workflows"]
-
-
-
-class AnalysisDetailSerializer(AnalysisBaseSerializer):
-    """
-    Serializer to define a detailed representation of an Analysis record,
-    mainly used in individual record views.
-    """
-    from .analysis_context import AnalysisContextSerializer
-    from .workflow import WorkflowMinSerializer
 
     contexts = AnalysisContextSerializer(many=True, read_only=True)
-    workflows = WorkflowMinSerializer(many=True, read_only=True)
+    workflows = WorkflowSerializer(many=True, read_only=True)
 
     class Meta(OrcabusIdSerializerMetaMixin):
         model = Analysis
         fields = "__all__"
+
+
+class UpdatableAnalysisSerializer(AnalysisBaseSerializer):
+    class UpdatableIdSerializer(serializers.StringRelatedField):
+        def to_internal_value(self, data):
+            return data
+
+        def to_representation(self, instance):
+            return str(instance.orcabus_id)
+
+    contexts = UpdatableIdSerializer(
+        many=True,
+        help_text="List of AnalysisContext orcabusId",
+        required=False,
+    )
+    workflows = UpdatableIdSerializer(
+        many=True,
+        help_text="List of Workflow orcabusId",
+        required=False,
+    )
+
+    class Meta(OrcabusIdSerializerMetaMixin):
+        model = Analysis
+        fields = ["contexts", "workflows", "description", "status"]
+
+    @staticmethod
+    def handle_swagger_form_payload_format(ids):
+        if isinstance(ids, list) and len(ids) == 1:
+            if "," in ids[0]:
+                return str(ids[0]).split(",")
+        return ids
+
+    def update(self, instance, validated_data):
+        # If the description is just an empty string, skip.
+        if validated_data.get("description", None) == "":
+            validated_data.pop("description")
+
+        # If the contexts present, update the analysis contexts linking
+        if validated_data.get("contexts", None):
+            context_ids = validated_data.pop("contexts")
+            context_ids = self.handle_swagger_form_payload_format(context_ids)
+            contexts = AnalysisContext.objects.filter(pk__in=context_ids)
+            instance.contexts.set(contexts)
+
+        # If the workflows present, update the workflows linking
+        if validated_data.get("workflows", None):
+            workflow_ids = validated_data.pop("workflows")
+            workflow_ids = self.handle_swagger_form_payload_format(workflow_ids)
+            workflows = Workflow.objects.filter(pk__in=workflow_ids)
+            instance.workflows.set(workflows)
+
+        return super().update(instance, validated_data)

--- a/app/workflow_manager/serializers/analysis_context.py
+++ b/app/workflow_manager/serializers/analysis_context.py
@@ -1,5 +1,5 @@
-from workflow_manager.serializers.base import SerializersBase, OptionalFieldsMixin, OrcabusIdSerializerMetaMixin
 from workflow_manager.models import AnalysisContext
+from workflow_manager.serializers.base import SerializersBase, OptionalFieldsMixin, OrcabusIdSerializerMetaMixin
 
 
 class AnalysisContextBaseSerializer(SerializersBase):
@@ -22,3 +22,16 @@ class AnalysisContextSerializer(AnalysisContextBaseSerializer):
     class Meta(OrcabusIdSerializerMetaMixin):
         model = AnalysisContext
         fields = "__all__"
+
+
+class UpdatableAnalysisContextSerializer(AnalysisContextBaseSerializer):
+    class Meta(OrcabusIdSerializerMetaMixin):
+        model = AnalysisContext
+        fields = ["description", "status"]
+
+    def update(self, instance, validated_data):
+        # If the description is just an empty string, skip.
+        if validated_data.get("description", None) == "":
+            validated_data.pop("description")
+
+        return super().update(instance, validated_data)

--- a/app/workflow_manager/serializers/analysis_run.py
+++ b/app/workflow_manager/serializers/analysis_run.py
@@ -1,5 +1,5 @@
-from workflow_manager.serializers.base import SerializersBase, OptionalFieldsMixin, OrcabusIdSerializerMetaMixin
 from workflow_manager.models import AnalysisRun
+from workflow_manager.serializers.base import SerializersBase, OptionalFieldsMixin, OrcabusIdSerializerMetaMixin
 
 
 class AnalysisRunBaseSerializer(SerializersBase):
@@ -27,11 +27,11 @@ class AnalysisRunSerializer(AnalysisRunBaseSerializer):
 
 class AnalysisRunDetailSerializer(AnalysisRunBaseSerializer):
     from .library import LibrarySerializer
-    from .analysis import AnalysisDetailSerializer
+    from .analysis import AnalysisSerializer
     from .analysis_context import AnalysisContextSerializer
 
     libraries = LibrarySerializer(many=True, read_only=True)
-    analysis = AnalysisDetailSerializer(read_only=True)
+    analysis = AnalysisSerializer(read_only=True)
     storage_context = AnalysisContextSerializer(read_only=True)
     compute_context = AnalysisContextSerializer(read_only=True)
 

--- a/app/workflow_manager/serializers/workflow.py
+++ b/app/workflow_manager/serializers/workflow.py
@@ -1,5 +1,5 @@
-from workflow_manager.serializers.base import SerializersBase, OptionalFieldsMixin, OrcabusIdSerializerMetaMixin
 from workflow_manager.models import Workflow
+from workflow_manager.serializers.base import SerializersBase, OptionalFieldsMixin, OrcabusIdSerializerMetaMixin
 
 
 class WorkflowBaseSerializer(SerializersBase):
@@ -15,7 +15,7 @@ class WorkflowListParamSerializer(OptionalFieldsMixin, WorkflowBaseSerializer):
 class WorkflowMinSerializer(WorkflowBaseSerializer):
     class Meta(OrcabusIdSerializerMetaMixin):
         model = Workflow
-        fields = ["orcabus_id", "workflow_name", "workflow_version"]
+        fields = ["orcabus_id", "workflow_name", "workflow_version", "execution_engine"]
 
 
 class WorkflowSerializer(WorkflowBaseSerializer):

--- a/app/workflow_manager/viewsets/analysis.py
+++ b/app/workflow_manager/viewsets/analysis.py
@@ -1,22 +1,34 @@
 from drf_spectacular.utils import extend_schema
+from rest_framework import status
 
 from workflow_manager.models.analysis import Analysis
-from workflow_manager.serializers.analysis import AnalysisDetailSerializer, AnalysisSerializer, AnalysisListParamSerializer
-from .base import BaseViewSet
+from workflow_manager.serializers.analysis import AnalysisSerializer, AnalysisListParamSerializer, \
+    UpdatableAnalysisSerializer
+from .base import PatchOnlyViewSet
 
 
-class AnalysisViewSet(BaseViewSet):
-    serializer_class = AnalysisDetailSerializer  # use detailed serializer as default
+class AnalysisViewSet(PatchOnlyViewSet):
+    serializer_class = AnalysisSerializer
     search_fields = Analysis.get_base_fields()
     queryset = Analysis.objects.prefetch_related("contexts").prefetch_related("workflows").all()
+
+    def get_queryset(self):
+        query_params = self.request.query_params.copy()
+        return Analysis.objects.get_by_keyword(self.queryset, **query_params)
 
     @extend_schema(parameters=[
         AnalysisListParamSerializer
     ])
     def list(self, request, *args, **kwargs):
-        self.serializer_class = AnalysisSerializer  # use simple serializer for list view
         return super().list(request, *args, **kwargs)
 
-    def get_queryset(self):
-        query_params = self.request.query_params.copy()
-        return Analysis.objects.get_by_keyword(self.queryset, **query_params)
+    @extend_schema(
+        request=UpdatableAnalysisSerializer,
+        responses={
+            status.HTTP_200_OK: UpdatableAnalysisSerializer,
+        }
+    )
+    def partial_update(self, request, *args, **kwargs):
+        self.serializer_class = UpdatableAnalysisSerializer
+        kwargs['partial'] = True
+        return super().update(request, *args, **kwargs)

--- a/app/workflow_manager/viewsets/analysis_context.py
+++ b/app/workflow_manager/viewsets/analysis_context.py
@@ -1,13 +1,18 @@
 from drf_spectacular.utils import extend_schema
 
 from workflow_manager.models.analysis_context import AnalysisContext
-from workflow_manager.serializers.analysis_context import AnalysisContextSerializer, AnalysisContextListParamSerializer
-from .base import BaseViewSet
+from workflow_manager.serializers.analysis_context import AnalysisContextSerializer, AnalysisContextListParamSerializer, \
+    UpdatableAnalysisContextSerializer
+from .base import PatchOnlyViewSet
 
 
-class AnalysisContextViewSet(BaseViewSet):
+class AnalysisContextViewSet(PatchOnlyViewSet):
     serializer_class = AnalysisContextSerializer
     search_fields = AnalysisContext.get_base_fields()
+
+    def get_queryset(self):
+        query_params = self.request.query_params.copy()
+        return AnalysisContext.objects.get_by_keyword(self.queryset, **query_params)
 
     @extend_schema(parameters=[
         AnalysisContextListParamSerializer
@@ -15,6 +20,10 @@ class AnalysisContextViewSet(BaseViewSet):
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 
-    def get_queryset(self):
-        query_params = self.request.query_params.copy()
-        return AnalysisContext.objects.get_by_keyword(self.queryset, **query_params)
+    @extend_schema(
+        request=UpdatableAnalysisContextSerializer,
+    )
+    def partial_update(self, request, *args, **kwargs):
+        self.serializer_class = UpdatableAnalysisContextSerializer
+        kwargs['partial'] = True
+        return super().update(request, *args, **kwargs)

--- a/app/workflow_manager/viewsets/base.py
+++ b/app/workflow_manager/viewsets/base.py
@@ -1,9 +1,9 @@
 from abc import ABC
-from rest_framework import filters
-from django.shortcuts import get_object_or_404
+
+from rest_framework import filters, mixins
+from rest_framework.viewsets import ReadOnlyModelViewSet, GenericViewSet
+
 from workflow_manager.pagination import StandardResultsSetPagination
-from rest_framework.response import Response
-from rest_framework.viewsets import ReadOnlyModelViewSet
 
 
 class BaseViewSet(ReadOnlyModelViewSet, ABC):
@@ -12,3 +12,16 @@ class BaseViewSet(ReadOnlyModelViewSet, ABC):
     ordering = ["-orcabus_id"]
     pagination_class = StandardResultsSetPagination
     filter_backends = [filters.OrderingFilter, filters.SearchFilter]
+
+
+class PatchOnlyViewSet(mixins.CreateModelMixin,
+                       mixins.RetrieveModelMixin,
+                       mixins.UpdateModelMixin,
+                       mixins.ListModelMixin,
+                       GenericViewSet, ABC):
+    lookup_value_regex = "[^/]+"  # This is to allow for special characters in the URL
+    ordering_fields = "__all__"
+    ordering = ["-orcabus_id"]
+    pagination_class = StandardResultsSetPagination
+    filter_backends = [filters.OrderingFilter, filters.SearchFilter]
+    http_method_names = ['get', 'post', 'patch', 'head', 'options', 'trace']  # no PUT method and PATCH only for update


### PR DESCRIPTION
* Chiefly, we can now create Analysis and AnalysisContext via API
* Implemented `PatchOnlyViewSet` controller part of MVC
* Implemented `UpdatableAnalysisSerializer` view part of MVC
  * Allow to create via POST
  * Allow partial update to the "updatable fields only" via PATCH
* Minor refactor to analysis and workflow view serializers
