### PR TITLE
Fixed unittest cases for Workflow Execution Engine ICA

### DIFF
--- a/app/workflow_manager/tests/factories.py
+++ b/app/workflow_manager/tests/factories.py
@@ -30,7 +30,7 @@ class WorkflowFactory(factory.django.DjangoModelFactory):
     workflow_name = "TestWorkflow"
     workflow_version = "1.0"
     execution_engine_pipeline_id = str(uuid.uuid4())
-    execution_engine = "ICAv2"
+    execution_engine = "ICA"
 
 
 class PayloadFactory(factory.django.DjangoModelFactory):

--- a/app/workflow_manager/tests/fixtures/sim_analysis.py
+++ b/app/workflow_manager/tests/fixtures/sim_analysis.py
@@ -168,7 +168,7 @@ class TestData:
         qc_workflow = Workflow(
             workflow_name="wgts_alignment_qc",
             workflow_version="1.0",
-            execution_engine="ICAv2",
+            execution_engine="ICA",
             execution_engine_pipeline_id="ica.pipeline.01234",
         )
         qc_workflow.save()
@@ -176,7 +176,7 @@ class TestData:
         wgs_workflow = Workflow(
             workflow_name="tumor_normal",
             workflow_version="1.0",
-            execution_engine="ICAv2",
+            execution_engine="ICA",
             execution_engine_pipeline_id="ica.pipeline.12345",
         )
         wgs_workflow.save()
@@ -184,7 +184,7 @@ class TestData:
         cttsov2_workflow = Workflow(
             workflow_name="cttso",
             workflow_version="2.0",
-            execution_engine="ICAv2",
+            execution_engine="ICA",
             execution_engine_pipeline_id="ica.pipeline.23456",
         )
         cttsov2_workflow.save()
@@ -192,7 +192,7 @@ class TestData:
         umccrise_workflow = Workflow(
             workflow_name="umccrise",
             workflow_version="1.0",
-            execution_engine="ICAv2",
+            execution_engine="ICA",
             execution_engine_pipeline_id="ica.pipeline.34567",
         )
         umccrise_workflow.save()

--- a/app/workflow_manager/tests/test_models.py
+++ b/app/workflow_manager/tests/test_models.py
@@ -21,7 +21,7 @@ class WorkflowModelTests(TestCase):
         mock_wfl = Workflow(
             workflow_name="test_workflow",
             workflow_version="0.0.1",
-            execution_engine="CIA",
+            execution_engine="ICA",
             execution_engine_pipeline_id=str(uuid.uuid4()),
         )
         mock_wfl.save()

--- a/app/workflow_manager_proc/tests/fixtures/WRSC_max.json
+++ b/app/workflow_manager_proc/tests/fixtures/WRSC_max.json
@@ -18,7 +18,7 @@
       "orcabusId": "wfl.01J5M2JFE1JPYV62RYQEG99CPW",
       "name": "bssh_icav2_fastq_copy",
       "version": "1.2.3",
-      "executionEngine": "ICAv2"
+      "executionEngine": "ICA"
     },
     "analysisRun": {
       "orcabusId": "anr.01J5M2JFE1JPYV62RYQEG99RUN",

--- a/app/workflow_manager_proc/tests/fixtures/WRSC_min.json
+++ b/app/workflow_manager_proc/tests/fixtures/WRSC_min.json
@@ -18,7 +18,7 @@
       "orcabusId": "wfl.01J5M2JFE1JPYV62RYQEG99CPW",
       "name": "bssh_icav2_fastq_copy",
       "version": "1.2.3",
-      "executionEngine": "ICAv2"
+      "executionEngine": "ICA"
     },
     "status": "DRAFT"
   }


### PR DESCRIPTION
* Drop the version from the engine value which now becomes controlled enum type. We should model it in with a separate column field if we would like to track. these differences. e.g. `execution_engine_version`