### PR TITLE
Improved Workflow API endpoints

### DIFF
--- a/app/workflow_manager/serializers/workflow.py
+++ b/app/workflow_manager/serializers/workflow.py
@@ -22,3 +22,16 @@ class WorkflowSerializer(WorkflowBaseSerializer):
     class Meta(OrcabusIdSerializerMetaMixin):
         model = Workflow
         fields = "__all__"
+
+
+class UpdatableWorkflowSerializer(WorkflowBaseSerializer):
+    class Meta(OrcabusIdSerializerMetaMixin):
+        model = Workflow
+        fields = ["execution_engine_pipeline_id"]
+
+    def update(self, instance, validated_data):
+        # If the execution_engine_pipeline_id is just an empty string, skip.
+        if validated_data.get("execution_engine_pipeline_id", None) == "":
+            validated_data.pop("execution_engine_pipeline_id")
+
+        return super().update(instance, validated_data)

--- a/app/workflow_manager/viewsets/workflow.py
+++ b/app/workflow_manager/viewsets/workflow.py
@@ -1,13 +1,19 @@
 from drf_spectacular.utils import extend_schema
+from rest_framework import status
 
 from workflow_manager.models.workflow import Workflow
-from workflow_manager.serializers.workflow import WorkflowSerializer, WorkflowListParamSerializer
-from workflow_manager.viewsets.base import BaseViewSet
+from workflow_manager.serializers.workflow import WorkflowSerializer, WorkflowListParamSerializer, \
+    UpdatableWorkflowSerializer
+from workflow_manager.viewsets.base import PatchOnlyViewSet
 
 
-class WorkflowViewSet(BaseViewSet):
+class WorkflowViewSet(PatchOnlyViewSet):
     serializer_class = WorkflowSerializer
     search_fields = Workflow.get_base_fields()
+
+    def get_queryset(self):
+        query_params = self.request.query_params.copy()
+        return Workflow.objects.get_by_keyword(self.queryset, **query_params)
 
     @extend_schema(parameters=[
         WorkflowListParamSerializer
@@ -15,6 +21,13 @@ class WorkflowViewSet(BaseViewSet):
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 
-    def get_queryset(self):
-        query_params = self.request.query_params.copy()
-        return Workflow.objects.get_by_keyword(self.queryset, **query_params)
+    @extend_schema(
+        request=UpdatableWorkflowSerializer,
+        responses={
+            status.HTTP_200_OK: UpdatableWorkflowSerializer,
+        }
+    )
+    def partial_update(self, request, *args, **kwargs):
+        self.serializer_class = UpdatableWorkflowSerializer
+        kwargs['partial'] = True
+        return super().update(request, *args, **kwargs)


### PR DESCRIPTION
* Chiefly, we can now create Workflow via API that extends `PatchOnlyViewSet`
  and implements `UpdatableWorkflowSerializer` of MVC
  * Allow to create via POST
  * Allow partial update to the "updatable fields only" via PATCH
