### PR TITLE
Implemented WorkflowManager Schema Registry

### DIFF
--- a/infrastructure/stage/schema.ts
+++ b/infrastructure/stage/schema.ts
@@ -1,0 +1,86 @@
+import { Construct } from 'constructs';
+import { aws_eventschemas } from 'aws-cdk-lib';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+export interface SchemaProps {
+  schemaName: string;
+  schemaDescription: string;
+  schemaLocation: string;
+}
+
+export class WorkflowManagerSchemaRegistry extends Construct {
+  private readonly SCHEMA_REGISTRY_NAME = 'orcabus.workflowmanager';
+  private readonly SCHEMA_TYPE = 'JSONSchemaDraft4';
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    // Create EventBridge schema registry
+    new aws_eventschemas.CfnRegistry(this, this.SCHEMA_REGISTRY_NAME, {
+      registryName: this.SCHEMA_REGISTRY_NAME,
+      description: 'Schema Registry for ' + this.SCHEMA_REGISTRY_NAME,
+    });
+
+    // Publish schema into the registry
+    getSchemas().forEach((s) => {
+      this.publish(s);
+    });
+  }
+
+  private publish(props: SchemaProps) {
+    const content: string = this.getSchemaContent(props.schemaLocation);
+
+    new aws_eventschemas.CfnSchema(this, props.schemaName, {
+      content: content,
+      registryName: this.SCHEMA_REGISTRY_NAME,
+      type: this.SCHEMA_TYPE,
+      description: props.schemaDescription,
+      schemaName: props.schemaName,
+    });
+  }
+
+  private getSchemaContent(loc: string): string {
+    return readFileSync(loc, 'utf-8');
+  }
+}
+
+export const getSchemas = (): Array<SchemaProps> => {
+  const docBase: string = '../../docs/events';
+
+  // Add new schema to the list
+  return [
+    {
+      schemaName: 'orcabus.workflowmanager@WorkflowRunStateChange',
+      schemaDescription: 'State change event for workflow run by WorkflowManager',
+      schemaLocation: path.join(
+        __dirname,
+        docBase + '/WorkflowRunStateChange/WorkflowRunStateChange.schema.json'
+      ),
+    },
+    {
+      schemaName: 'orcabus.workflowmanager@WorkflowRunUpdate',
+      schemaDescription: 'Update event for workflow run by external service',
+      schemaLocation: path.join(
+        __dirname,
+        docBase + '/WorkflowRunUpdate/WorkflowRunUpdate.schema.json'
+      ),
+    },
+    {
+      schemaName: 'orcabus.workflowmanager@AnalysisRunStateChange',
+      schemaDescription: 'State change event for analysis run by WorkflowManager',
+      schemaLocation: path.join(
+        __dirname,
+        docBase + '/AnalysisRunStateChange/AnalysisRunStateChange.schema.json'
+      ),
+    },
+    {
+      schemaName: 'orcabus.workflowmanager@AnalysisRunUpdate',
+      schemaDescription: 'Update event for analysis run by external service',
+      schemaLocation: path.join(
+        __dirname,
+        docBase + '/AnalysisRunUpdate/AnalysisRunUpdate.schema.json'
+      ),
+    },
+  ];
+};

--- a/infrastructure/stage/stack.ts
+++ b/infrastructure/stage/stack.ts
@@ -24,6 +24,7 @@ import {
   DB_CLUSTER_IDENTIFIER,
   DB_CLUSTER_RESOURCE_ID_PARAMETER_NAME,
 } from '@orcabus/platform-cdk-constructs/shared-config/database';
+import { WorkflowManagerSchemaRegistry } from './schema';
 
 export interface WorkflowManagerStackProps extends StackProps {
   lambdaSecurityGroupName: string;
@@ -58,6 +59,9 @@ export class WorkflowManagerStack extends Stack {
       props.lambdaSecurityGroupName,
       this.vpc
     );
+
+    // Create the registry and publish the schemas
+    new WorkflowManagerSchemaRegistry(this, 'WorkflowManagerSchemaRegistry');
 
     this.lambdaRole = new Role(this, 'LambdaRole', {
       assumedBy: new ServicePrincipal('lambda.amazonaws.com'),

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -1,0 +1,38 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { WorkflowManagerSchemaRegistry } from '../infrastructure/stage/schema';
+
+let stack: cdk.Stack;
+
+beforeEach(() => {
+  stack = new cdk.Stack();
+});
+
+test('Test orcabus.workflowmanager WorkflowManagerSchemaRegistry Creation', () => {
+  // pnpm test --- test/schema.test.ts
+
+  new WorkflowManagerSchemaRegistry(stack, 'TestWorkflowManagerSchemaRegistry');
+  const template = Template.fromStack(stack);
+
+  console.log(template.toJSON());
+
+  template.hasResourceProperties('AWS::EventSchemas::Registry', {
+    RegistryName: 'orcabus.workflowmanager',
+  });
+
+  template.hasResourceProperties('AWS::EventSchemas::Schema', {
+    SchemaName: 'orcabus.workflowmanager@WorkflowRunStateChange',
+  });
+
+  template.hasResourceProperties('AWS::EventSchemas::Schema', {
+    SchemaName: 'orcabus.workflowmanager@WorkflowRunUpdate',
+  });
+
+  template.hasResourceProperties('AWS::EventSchemas::Schema', {
+    SchemaName: 'orcabus.workflowmanager@AnalysisRunStateChange',
+  });
+
+  template.hasResourceProperties('AWS::EventSchemas::Schema', {
+    SchemaName: 'orcabus.workflowmanager@AnalysisRunUpdate',
+  });
+});


### PR DESCRIPTION
* Implemented WorkflowManagerSchemaRegistry construct to provision the
  EventBridge registry and publish the WFM event schemas.
* Added IaC code unittest respectively

  Robustness rule-of-thumb:
     "By choosing CDK imperative programming model, it allows to do unittest on Infra-as-Code (IaC) changes"

Resolves #13
