### PR TITLE
Fixed WorkflowRun Stat API endpoint on refactored workflow name usage

### DIFF
--- a/app/workflow_manager/management/commands/generate_mock_workflow_run.py
+++ b/app/workflow_manager/management/commands/generate_mock_workflow_run.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # don't do anything if there is already mock data
-        if Workflow.objects.filter(workflow_name__startswith=TestData.WORKFLOW_NAME).exists():
+        if Workflow.objects.filter(name__startswith=TestData.WORKFLOW_NAME).exists():
             print("Mock data found, Skipping creation.")
             return
 

--- a/app/workflow_manager/viewsets/workflow_run.py
+++ b/app/workflow_manager/viewsets/workflow_run.py
@@ -86,7 +86,7 @@ class WorkflowRunViewSet(BaseViewSet):
                 Q(comment__icontains=search_params) |
                 Q(libraries__library_id__icontains=search_params) |
                 Q(libraries__orcabus_id__icontains=search_params) |
-                Q(workflow__workflow_name__icontains=search_params)
+                Q(workflow__name__icontains=search_params)
             ).distinct() # Add distinct to remove duplicates
 
         return result_set

--- a/app/workflow_manager/viewsets/workflow_run_stats.py
+++ b/app/workflow_manager/viewsets/workflow_run_stats.py
@@ -84,7 +84,7 @@ class WorkflowRunStatsViewSet(mixins.ListModelMixin, GenericViewSet):
                 Q(comment__icontains=search_params) |
                 Q(libraries__library_id__icontains=search_params) |
                 Q(libraries__orcabus_id__icontains=search_params) |
-                Q(workflow__workflow_name__icontains=search_params)
+                Q(workflow__name__icontains=search_params)
             ).distinct()
 
         return result_set


### PR DESCRIPTION
* The WorkflowRun stat endpoint use Django query construct `workflow__workflow_name`
  which breaks when `?search` API call is used via UI.
* Follow-up of #96
