### PR TITLE
Fixed Payload API endpoint data field as an opaque object

### DIFF
--- a/app/workflow_manager/settings/base.py
+++ b/app/workflow_manager/settings/base.py
@@ -142,7 +142,8 @@ REST_FRAMEWORK = {
         "djangorestframework_camel_case.parser.CamelCaseJSONParser",
     ),
     "JSON_UNDERSCOREIZE": {
-        'no_underscore_before_number': True,
+        "no_underscore_before_number": True,
+        "ignore_fields": ("data",),  # Treat model field name "data" as an opaque object. Do not transform recursively.
     },
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.TokenAuthentication",

--- a/app/workflow_manager/tests/fixtures/sim_analysis.py
+++ b/app/workflow_manager/tests/fixtures/sim_analysis.py
@@ -530,7 +530,26 @@ class TestData:
                 timestamp=datetime.now(timezone.utc),
                 payload=PayloadFactory(
                     payload_ref_id=str(uuid.uuid4()),
-                    data={"comment": f"Payload for initial state of wfr.{wr.orcabus_id}"}),
+                    data={
+                        "comment": f"Payload for initial state of wfr.{wr.orcabus_id}",
+                        "under_score": "foo",
+                        "key-with-dash": "bar",
+                        "PascalCase": "bash",
+                        "inputs": {
+                            "forceGenome": True,
+                            "genome_type": "alt",
+                            "genome_version": "38",
+                            "genomes": {
+                                "GRCh38_umccr": {
+                                    "fai": "s3://reference-data/refdata/genomes/GRCh38_umccr/foo/bar/GRCh38.fa.fai"
+                                }
+                            }
+                        },
+                        "engineParameters": {
+                            "logsUri": "s3://reference-data/refdata/logs/",
+                            "logs_uri": "s3://underscore-data/refdata/logs/",
+                        }
+                    }),
                 comment="Initial State"
             )
             initial_state.save()


### PR DESCRIPTION
* Configured JSON parser to treat model field name "data" as an opaque object
  and do not transform the keys recursively to camelCase.
* Added unittest to guard around this API contract
