### PR TITLE
Allow deprecated all other ongoing state

### DIFF
--- a/app/workflow_manager/viewsets/state.py
+++ b/app/workflow_manager/viewsets/state.py
@@ -92,7 +92,7 @@ class StateViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, mixins.List
         instance = self.get_object()
 
         # Check if the state being updated is in the validation map
-        if not self.is_valid_next_state(instance.status, request.data.get('status')):
+        if instance.status not in self.states_transition_validation_map:
             return Response({"detail": "Invalid state status."},
                             status=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
Fix for #115 
```python
"""
    states_transition_validation_map for state creation, update
    Structure:
    - If value is a list: ['STATE1', 'STATE2'] means only these states can transition to the key
    - If value is a dict with 'excluded_states': allows all states except those listed
    - If value is a dict with 'allowed_states': same as list format

    refer:
        "Resolved" -- https://github.com/umccr/orcabus/issues/593
        "Deprecated" -- https://github.com/umccr/orcabus/issues/695
   """
    states_transition_validation_map = {
        'RESOLVED': ['FAILED'],  # Only FAILED can transition to RESOLVED
        'DEPRECATED': {'excluded_states': ['FAILED', 'ABORTED', 'RESOLVED', 'DEPRECATED']}  # All states except these can transition to DEPRECATED
    }
```
UI PR: https://github.com/umccr/orca-ui/pull/218
Test on DEV: https://orcaui.dev.umccr.org/runs/workflow?workflowRunStatus=ongoing