### PR TITLE
Fixed unittest Makefile test target

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -144,6 +144,6 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: workflow_manager.settings.it
           DB_HOSTNAME: localhost
-          DB_PORT: 5435
+          DB_PORT: 5432
         run: |
           make test

--- a/app/Makefile
+++ b/app/Makefile
@@ -270,10 +270,14 @@ run-mock: reset-db migrate mock start
 
 
 # Test commands
-.PHONY: test suite
+.PHONY: test suite test-aws
 
-# alias to test suite
-test: install test-up suite test-down
+# on local dev, you need to `make up` yourself
+# on github action, it leverages github built-in service container (cache docker image) to avoid rate limit
+test: install suite
+
+# on AWS CICD pipeline, need to pull docker image from the aws ecr public registry to avoid the rate limit
+test-aws: install test-up suite test-down
 
 suite:
 	python manage.py test

--- a/app/compose_test.yml
+++ b/app/compose_test.yml
@@ -21,9 +21,10 @@ services:
       retries: 5
       start_period: 90s
 
-  localstack:
-    # Use a version that align with upper bound of AWS LocalStack LTS
-    image: public.ecr.aws/localstack/localstack:3
-    container_name: orcabus_localstack_test
-    ports:
-      - '4566:4566'
+# FIXME don't think the localstack is needed  ~victor
+#  localstack:
+#    # Use a version that align with upper bound of AWS LocalStack LTS
+#    image: public.ecr.aws/localstack/localstack:3
+#    container_name: orcabus_localstack_test
+#    ports:
+#      - '4566:4566'

--- a/infrastructure/toolchain/stateless-stack.ts
+++ b/infrastructure/toolchain/stateless-stack.ts
@@ -24,7 +24,7 @@ export class StatelessStack extends cdk.Stack {
       unitAppTestConfig: {
         command: [
           'cd app',
-          'DJANGO_SETTINGS_MODULE=workflow_manager.settings.it DB_PORT=5435 make test',
+          'DJANGO_SETTINGS_MODULE=workflow_manager.settings.it DB_PORT=5435 make test-aws',
         ],
       },
     });


### PR DESCRIPTION
* Reorganised docker stack to suit each CICD environment.

  On GitHub Action CICD, we leverage its built-in service container. 
  On AWS CodePipeline, we leverage AWS ECR Public Registry. 
  This effectively reduces the docker image pull request rate limit 
  as the image registry are affinity to respective network and maintain 
  optimal CICD operation.
