### PR TITLE
Fix/fix workflow run detail schema

### DIFF
--- a/app/workflow_manager/serializers/analysis_run_state.py
+++ b/app/workflow_manager/serializers/analysis_run_state.py
@@ -9,7 +9,7 @@ class AnalysisRunStateBaseSerializer(SerializersBase):
 class AnalysisRunStateMinSerializer(AnalysisRunStateBaseSerializer):
     class Meta(OrcabusIdSerializerMetaMixin):
         model = AnalysisRunState
-        fields = ["orcabus_id", "status", "timestamp", "comment"]
+        fields = ["orcabus_id", "status", "timestamp"]
 
 
 class AnalysisRunStateSerializer(AnalysisRunStateBaseSerializer):

--- a/app/workflow_manager/serializers/workflow_run.py
+++ b/app/workflow_manager/serializers/workflow_run.py
@@ -13,7 +13,7 @@ class WorkflowRunBaseSerializer(SerializersBase):
     current_state = serializers.SerializerMethodField()
 
     @extend_schema_field(StateMinSerializer(allow_null=True))
-    def get_current_state(self, obj) -> dict:
+    def get_current_state(self, obj) -> dict | None:
         latest_state = obj.get_latest_state()
         return StateMinSerializer(latest_state).data if latest_state else None
 
@@ -105,7 +105,6 @@ class WorkflowRunDetailSerializer(WorkflowRunBaseSerializer):
     libraries = LibrarySerializer(many=True, read_only=True)
     workflow = WorkflowSerializer(read_only=True)
     analysis_run = AnalysisRunSerializer(read_only=True)
-    # current_state = serializers.SerializerMethodField()
     contexts = RunContextSerializer(many=True, read_only=True)
     readsets = ReadsetSerializer(many=True, read_only=True)
 

--- a/app/workflow_manager/serializers/workflow_run.py
+++ b/app/workflow_manager/serializers/workflow_run.py
@@ -97,11 +97,15 @@ class WorkflowRunDetailSerializer(WorkflowRunBaseSerializer):
     from .library import LibrarySerializer
     from .workflow import WorkflowSerializer
     from .analysis_run import AnalysisRunSerializer
+    from .run_context import RunContextSerializer
+    from .readset import ReadsetSerializer
 
     libraries = LibrarySerializer(many=True, read_only=True)
     workflow = WorkflowSerializer(read_only=True)
     analysis_run = AnalysisRunSerializer(read_only=True)
     current_state = serializers.SerializerMethodField()
+    contexts = RunContextSerializer(many=True, read_only=True)
+    readsets = ReadsetSerializer(many=True, read_only=True)
 
     class Meta(OrcabusIdSerializerMetaMixin):
         model = WorkflowRun

--- a/app/workflow_manager/serializers/workflow_run.py
+++ b/app/workflow_manager/serializers/workflow_run.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from rest_framework.settings import api_settings
+from drf_spectacular.utils import extend_schema_field
 
 from workflow_manager.serializers.base import SerializersBase, OptionalFieldsMixin, OrcabusIdSerializerMetaMixin
 from workflow_manager.models import WorkflowRun
@@ -11,6 +12,7 @@ class WorkflowRunBaseSerializer(SerializersBase):
     # all states are available via a dedicated endpoint
     current_state = serializers.SerializerMethodField()
 
+    @extend_schema_field(StateMinSerializer(allow_null=True))
     def get_current_state(self, obj) -> dict:
         latest_state = obj.get_latest_state()
         return StateMinSerializer(latest_state).data if latest_state else None
@@ -103,7 +105,7 @@ class WorkflowRunDetailSerializer(WorkflowRunBaseSerializer):
     libraries = LibrarySerializer(many=True, read_only=True)
     workflow = WorkflowSerializer(read_only=True)
     analysis_run = AnalysisRunSerializer(read_only=True)
-    current_state = serializers.SerializerMethodField()
+    # current_state = serializers.SerializerMethodField()
     contexts = RunContextSerializer(many=True, read_only=True)
     readsets = ReadsetSerializer(many=True, read_only=True)
 

--- a/app/workflow_manager/tests/test_serializers.py
+++ b/app/workflow_manager/tests/test_serializers.py
@@ -213,3 +213,51 @@ class AnalysisRunSerializerTests(TestCase):
         serializer = AnalysisRunDetailSerializer(ar)
         data = serializer.data
         self.assertEqual(data["states"], [])
+
+
+class WorkflowRunSerializerTests(TestCase):
+    def test_detail_serializer_includes_nested_contexts_and_readsets(self):
+        from workflow_manager.models import Readset, RunContext
+        from workflow_manager.models.run_context import RunContextUseCase
+        from workflow_manager.serializers.workflow_run import WorkflowRunDetailSerializer
+        from workflow_manager.tests.factories import WorkflowRunFactory
+
+        workflow_run = WorkflowRunFactory()
+        context = RunContext.objects.create(
+            name="compute-context",
+            usecase=RunContextUseCase.COMPUTE,
+            description="primary compute context",
+        )
+        readset = Readset.objects.create(
+            rgid="rg1",
+            library_id="L000001",
+            library_orcabus_id="lib-orca-1",
+        )
+        workflow_run.contexts.add(context)
+        workflow_run.readsets.add(readset)
+
+        serializer = WorkflowRunDetailSerializer(workflow_run)
+        data = serializer.data
+
+        self.assertEqual(len(data["contexts"]), 1)
+        self.assertEqual(data["contexts"][0]["orcabus_id"], context.orcabus_id)
+        self.assertEqual(data["contexts"][0]["name"], context.name)
+        self.assertEqual(data["contexts"][0]["usecase"], context.usecase)
+        self.assertEqual(len(data["readsets"]), 1)
+        self.assertEqual(data["readsets"][0]["orcabus_id"], readset.orcabus_id)
+        self.assertEqual(data["readsets"][0]["rgid"], readset.rgid)
+        self.assertEqual(data["readsets"][0]["library_id"], readset.library_id)
+        self.assertEqual(
+            data["readsets"][0]["library_orcabus_id"],
+            readset.library_orcabus_id,
+        )
+
+    def test_detail_serializer_returns_null_current_state_when_no_states(self):
+        from workflow_manager.serializers.workflow_run import WorkflowRunDetailSerializer
+        from workflow_manager.tests.factories import WorkflowRunFactory
+
+        workflow_run = WorkflowRunFactory()
+
+        serializer = WorkflowRunDetailSerializer(workflow_run)
+
+        self.assertIsNone(serializer.data["current_state"])

--- a/app/workflow_manager/viewsets/workflow_run.py
+++ b/app/workflow_manager/viewsets/workflow_run.py
@@ -27,7 +27,7 @@ class WorkflowRunViewSet(BaseViewSet):
     """
     serializer_class = WorkflowRunDetailSerializer
     search_fields = WorkflowRun.get_base_fields()
-    queryset = WorkflowRun.objects.prefetch_related("libraries").all()
+    queryset = WorkflowRun.objects.all()
     termination_statuses = ["FAILED", "ABORTED", "SUCCEEDED", "RESOLVED", "DEPRECATED"]
     http_method_names = ['get', 'head', 'options', 'trace']
     # Ordering and search are handled in get_queryset / filtered_workflow_runs_queryset;
@@ -60,6 +60,9 @@ class WorkflowRunViewSet(BaseViewSet):
             apply_status_filter=True,
             annotate_latest_state_time=needs_timestamp_order,
         )
+
+        if self.action == "retrieve":
+            result_set = result_set.prefetch_related("contexts", "readsets")
 
         if needs_timestamp_order:
             if validated == "timestamp":


### PR DESCRIPTION
Quick fix for workflow run detail schema. No changes for API actions or DB model.

## Summary
This PR fixes WorkflowRun detail schema and keeps query performance aligned with actual response usage.

## Changes

- Added schema annotation for WorkflowRun current_state as nullable.
- Updated WorkflowRun detail response to include nested contexts and readsets.
- Removed comment from AnalysisRunState min serializer.
- Added serializer tests for:
  - nested contexts/readsets in WorkflowRun detail
  - null current_state when no state exists