### PR TITLE
add improve to workflow manager api

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -3,10 +3,35 @@
 
 See README https://github.com/logandk/serverless-wsgi
 """
+import logging
+
 import serverless_wsgi
 
 from workflow_manager.wsgi import application
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
 
 def handler(event, context):
-    return serverless_wsgi.handle_request(application, event, context)
+    """Lambda entrypoint for the API with exception logging for CloudWatch."""
+    try:
+        return serverless_wsgi.handle_request(application, event, context)
+    except Exception as exc:
+        remaining_ms = None
+        if context is not None and hasattr(context, "get_remaining_time_in_millis"):
+            remaining_ms = context.get_remaining_time_in_millis()
+
+        request_id = getattr(context, "aws_request_id", None)
+        http_method = event.get("httpMethod") if isinstance(event, dict) else None
+        path = event.get("path") if isinstance(event, dict) else None
+
+        logger.exception(
+            "API Lambda request failed: request_id=%s remaining_ms=%s method=%s path=%s error_type=%s",
+            request_id,
+            remaining_ms,
+            http_method,
+            path,
+            type(exc).__name__,
+        )
+        raise

--- a/app/api.py
+++ b/app/api.py
@@ -13,6 +13,26 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+def _get_request_details(event):
+    """Return HTTP method and path from API Gateway v2 events, with v1 fallbacks."""
+    if not isinstance(event, dict):
+        return None, None
+
+    request_context = event.get("requestContext")
+    http_context = request_context.get("http") if isinstance(request_context, dict) else None
+
+    http_method = None
+    path = None
+    if isinstance(http_context, dict):
+        http_method = http_context.get("method")
+        path = http_context.get("path")
+
+    http_method = http_method or event.get("httpMethod")
+    path = event.get("rawPath") or path or event.get("path")
+
+    return http_method, path
+
+
 def handler(event, context):
     """Lambda entrypoint for the API with exception logging for CloudWatch."""
     try:
@@ -23,8 +43,7 @@ def handler(event, context):
             remaining_ms = context.get_remaining_time_in_millis()
 
         request_id = getattr(context, "aws_request_id", None)
-        http_method = event.get("httpMethod") if isinstance(event, dict) else None
-        path = event.get("path") if isinstance(event, dict) else None
+        http_method, path = _get_request_details(event)
 
         logger.exception(
             "API Lambda request failed: request_id=%s remaining_ms=%s method=%s path=%s error_type=%s",

--- a/app/workflow_manager/tests/test_api.py
+++ b/app/workflow_manager/tests/test_api.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import TestCase
+
+import api
+
+
+class ApiHandlerTests(TestCase):
+    def setUp(self):
+        self.context = SimpleNamespace(
+            aws_request_id="request-123",
+            function_name="workflow-manager-api",
+            log_stream_name="2026/04/24/[$LATEST]stream-123",
+            get_remaining_time_in_millis=lambda: 1234,
+        )
+        self.event = {
+            "httpMethod": "GET",
+            "path": "/api/v1/workflows/",
+        }
+
+    def test_handler_passes_successful_response_through(self):
+        expected_response = {"statusCode": 200, "body": "{}"}
+
+        with patch("api.serverless_wsgi.handle_request", return_value=expected_response) as mock_handle_request:
+            response = api.handler(self.event, self.context)
+
+        self.assertEqual(response, expected_response)
+        mock_handle_request.assert_called_once_with(api.application, self.event, self.context)
+
+    def test_handler_logs_context_when_wsgi_handler_raises(self):
+        error = RuntimeError("gateway timeout")
+
+        with (
+            patch("api.serverless_wsgi.handle_request", side_effect=error),
+            patch("api.logger.exception") as mock_logger_exception,
+        ):
+            with self.assertRaises(RuntimeError):
+                api.handler(self.event, self.context)
+
+        mock_logger_exception.assert_called_once()
+        message, *args = mock_logger_exception.call_args.args
+        self.assertIn("API Lambda request failed", message)
+        self.assertEqual(
+            args,
+            [
+                "request-123",
+                1234,
+                "GET",
+                "/api/v1/workflows/",
+                "RuntimeError",
+            ],
+        )

--- a/app/workflow_manager/tests/test_api.py
+++ b/app/workflow_manager/tests/test_api.py
@@ -1,12 +1,12 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase
 
 import api
 
 
-class ApiHandlerTests(TestCase):
+class ApiHandlerTests(SimpleTestCase):
     def setUp(self):
         self.context = SimpleNamespace(
             aws_request_id="request-123",
@@ -48,6 +48,70 @@ class ApiHandlerTests(TestCase):
                 1234,
                 "GET",
                 "/api/v1/workflows/",
+                "RuntimeError",
+            ],
+        )
+
+    def test_handler_logs_http_api_v2_request_details_when_wsgi_handler_raises(self):
+        error = RuntimeError("gateway timeout")
+        event = {
+            "rawPath": "/api/v1/workflows/",
+            "requestContext": {
+                "http": {
+                    "method": "POST",
+                    "path": "/stage/api/v1/workflows/",
+                },
+            },
+        }
+
+        with (
+            patch("api.serverless_wsgi.handle_request", side_effect=error),
+            patch("api.logger.exception") as mock_logger_exception,
+        ):
+            with self.assertRaises(RuntimeError):
+                api.handler(event, self.context)
+
+        mock_logger_exception.assert_called_once()
+        message, *args = mock_logger_exception.call_args.args
+        self.assertIn("API Lambda request failed", message)
+        self.assertEqual(
+            args,
+            [
+                "request-123",
+                1234,
+                "POST",
+                "/api/v1/workflows/",
+                "RuntimeError",
+            ],
+        )
+
+    def test_handler_falls_back_to_http_api_context_path_when_raw_path_is_missing(self):
+        error = RuntimeError("gateway timeout")
+        event = {
+            "requestContext": {
+                "http": {
+                    "method": "PATCH",
+                    "path": "/api/v1/workflows/1/",
+                },
+            },
+        }
+
+        with (
+            patch("api.serverless_wsgi.handle_request", side_effect=error),
+            patch("api.logger.exception") as mock_logger_exception,
+        ):
+            with self.assertRaises(RuntimeError):
+                api.handler(event, self.context)
+
+        mock_logger_exception.assert_called_once()
+        _message, *args = mock_logger_exception.call_args.args
+        self.assertEqual(
+            args,
+            [
+                "request-123",
+                1234,
+                "PATCH",
+                "/api/v1/workflows/1/",
                 "RuntimeError",
             ],
         )

--- a/infrastructure/stage/stack.ts
+++ b/infrastructure/stage/stack.ts
@@ -147,7 +147,7 @@ export class WorkflowManagerStack extends Stack {
     const apiFn: PythonFunction = this.createPythonFunction('Api', {
       index: 'api.py',
       handler: 'handler',
-      timeout: Duration.seconds(28),
+      timeout: Duration.minutes(2),
     });
 
     const wfmApi = new OrcaBusApiGateway(this, 'ApiGateway', props.apiGatewayCognitoProps);

--- a/infrastructure/stage/stack.ts
+++ b/infrastructure/stage/stack.ts
@@ -147,7 +147,7 @@ export class WorkflowManagerStack extends Stack {
     const apiFn: PythonFunction = this.createPythonFunction('Api', {
       index: 'api.py',
       handler: 'handler',
-      timeout: Duration.minutes(2),
+      timeout: Duration.seconds(29),
     });
 
     const wfmApi = new OrcaBusApiGateway(this, 'ApiGateway', props.apiGatewayCognitoProps);


### PR DESCRIPTION
Improve on https://github.com/OrcaBus/service-workflow-manager/issues/158

## Summary
This PR improves debugging for API Lambda failures by adding exception logging in the API Lambda entrypoint.

## Changes

- Add exception logging around the API Lambda WSGI handler.
- Add `_get_request_details()` helper to extract method/path from API Gateway HTTP API v2 events:
  - `requestContext.http.method`
  - `rawPath`
  - fallback to `requestContext.http.path`
- Keep compatibility with API Gateway v1-style events:
  - `httpMethod`
  - `path`
- Add focused tests for:
  - successful response pass-through
  - exception logging
  - API Gateway v1 event shape
  - API Gateway v2 event shape
  - fallback to `requestContext.http.path` when `rawPath` is missing
- Increase API Lambda timeout from 28s to 29s(The default integration timeout for Amazon API Gateway is 29 seconds).