### PR TITLE
emit wrsc events for state transition api

### DIFF
--- a/app/workflow_manager/aws_event_bridge/event.py
+++ b/app/workflow_manager/aws_event_bridge/event.py
@@ -1,10 +1,18 @@
 import os
 import logging
 from libumccr.aws import libeb
-from workflow_manager_proc.domain.event import wru
+from workflow_manager_proc.domain.event import wrsc, wru
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+
+class EventBridgePublishError(RuntimeError):
+    """Raised when EventBridge accepts a request but rejects its event entry."""
+
+    def __init__(self, message: str, failed_entries: list[dict] | None = None):
+        super().__init__(message)
+        self.failed_entries = failed_entries or []
 
 
 def emit_wru_api_event(event: dict):
@@ -35,3 +43,80 @@ def emit_wru_api_event(event: dict):
 
     logger.info(f"{__name__} done.")
     return response
+
+
+def emit_wrsc_api_event(event: dict, attempt_count: int = 1):
+    """Validate and emit a WorkflowRunStateChange created through the API."""
+    source = "orcabus.workflowmanager"
+    event_id = event.get("id", "unknown")
+    workflow_run_id = event.get("orcabusId", "unknown")
+    event_status = event.get("status", "unknown")
+
+    try:
+        event_bus_name = os.environ.get("EVENT_BUS_NAME", None)
+        if event_bus_name is None:
+            raise ValueError("EVENT_BUS_NAME environment variable is not set.")
+
+        validated = wrsc.WorkflowRunStateChange.model_validate(event)
+        detail_json = validated.model_dump_json(exclude_none=True)
+        event_id = validated.id
+        workflow_run_id = validated.orcabusId
+        event_status = validated.status
+
+        logger.info(
+            "Emitting WRSC event: event_id=%s workflow_run_id=%s status=%s attempt=%s",
+            event_id,
+            workflow_run_id,
+            event_status,
+            attempt_count,
+        )
+        response = libeb.emit_event(
+            {
+                "Source": source,
+                "DetailType": wrsc.WorkflowRunStateChange.__name__,
+                "Detail": detail_json,
+                "EventBusName": event_bus_name,
+            }
+        )
+
+        failed_entry_count = response.get("FailedEntryCount", 0)
+        if failed_entry_count:
+            failed_entries = [
+                {
+                    "error_code": entry.get("ErrorCode"),
+                    "error_message": entry.get("ErrorMessage"),
+                }
+                for entry in response.get("Entries", [])
+                if entry.get("ErrorCode") or entry.get("ErrorMessage")
+            ]
+            logger.error(
+                "EventBridge rejected WRSC event entry: event_id=%s workflow_run_id=%s status=%s attempt=%s failed_entry_count=%s failed_entries=%s",
+                event_id,
+                workflow_run_id,
+                event_status,
+                attempt_count,
+                failed_entry_count,
+                failed_entries,
+            )
+            raise EventBridgePublishError(
+                f"EventBridge rejected {failed_entry_count} WRSC event entry: {failed_entries}",
+                failed_entries=failed_entries,
+            )
+
+        logger.info(
+            "WRSC event emitted: event_id=%s workflow_run_id=%s status=%s attempt=%s",
+            event_id,
+            workflow_run_id,
+            event_status,
+            attempt_count,
+        )
+        return response
+    except Exception:
+        logger.exception(
+            "Failed to emit WRSC event: event_id=%s workflow_run_id=%s status=%s attempt=%s",
+            event_id,
+            workflow_run_id,
+            event_status,
+            attempt_count,
+        )
+        raise

--- a/app/workflow_manager/serializers/state.py
+++ b/app/workflow_manager/serializers/state.py
@@ -57,14 +57,26 @@ class StateBatchTransitionRequestSerializer(serializers.Serializer):
     comment = serializers.CharField(required=True, allow_blank=False)
 
 
+class StateBatchTransitionFailureSerializer(serializers.Serializer):
+    workflowrun_orcabus_id = serializers.CharField()
+    reason = serializers.CharField()
+    detail = serializers.CharField()
+    error = serializers.CharField(required=False)
+
+
 class StateBatchTransitionResponseSerializer(serializers.Serializer):
     """
-    Schema contract for 201 response from batch-state-transition.
-    JSON responses use camelCase (createdCount, workflowrunOrcabusIds).
+    Schema contract for batch-state-transition responses.
+    JSON responses use camelCase (createdCount, workflowrunOrcabusIds, failedCount).
     """
 
     created_count = serializers.IntegerField()
     workflowrun_orcabus_ids = serializers.ListField(
         child=serializers.CharField(),
         allow_empty=True,
+    )
+    failed_count = serializers.IntegerField(default=0)
+    failures = StateBatchTransitionFailureSerializer(
+        many=True,
+        required=False,
     )

--- a/app/workflow_manager/tests/test_event_bridge.py
+++ b/app/workflow_manager/tests/test_event_bridge.py
@@ -1,0 +1,86 @@
+import json
+import os
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from workflow_manager.aws_event_bridge.event import (
+    EventBridgePublishError,
+    emit_wrsc_api_event,
+)
+
+
+class WrscApiEventTestCase(SimpleTestCase):
+    def build_event(self):
+        return {
+            "id": "wrsc-event-id",
+            "version": "1.0.0",
+            "timestamp": timezone.now().isoformat(),
+            "orcabusId": "wfr.01J5M2JFE1JPYV62RYQEG99WR1",
+            "portalRunId": "20260623example",
+            "executionId": "execution-id",
+            "workflowRunName": "example-workflow-run",
+            "workflow": {
+                "orcabusId": "wfl.01J5M2JFE1JPYV62RYQEG99WFL",
+                "name": "example-workflow",
+                "version": "1.0.0",
+                "codeVersion": "1.0.0",
+                "executionEngine": "ICA",
+                "executionEnginePipelineId": "pipeline-id",
+                "validationState": "VALIDATED",
+            },
+            "status": "RESOLVED",
+        }
+
+    @patch.dict(os.environ, {"EVENT_BUS_NAME": "test-event-bus"})
+    @patch("workflow_manager.aws_event_bridge.event.libeb.emit_event")
+    def test_emit_wrsc_api_event_omits_payload(self, mock_emit_event):
+        mock_emit_event.return_value = {"FailedEntryCount": 0, "Entries": [{}]}
+
+        emit_wrsc_api_event(self.build_event(), attempt_count=2)
+
+        entry = mock_emit_event.call_args.args[0]
+        self.assertEqual(entry["Source"], "orcabus.workflowmanager")
+        self.assertEqual(entry["DetailType"], "WorkflowRunStateChange")
+        self.assertEqual(entry["EventBusName"], "test-event-bus")
+        detail = json.loads(entry["Detail"])
+        self.assertNotIn("payload", detail)
+        self.assertEqual(detail["status"], "RESOLVED")
+
+    @patch.dict(os.environ, {"EVENT_BUS_NAME": "test-event-bus"})
+    @patch("workflow_manager.aws_event_bridge.event.libeb.emit_event")
+    def test_emit_wrsc_api_event_raises_and_logs_partial_failure(self, mock_emit_event):
+        mock_emit_event.return_value = {
+            "FailedEntryCount": 1,
+            "Entries": [
+                {
+                    "ErrorCode": "InternalFailure",
+                    "ErrorMessage": "EventBridge failed",
+                }
+            ],
+        }
+
+        with self.assertLogs(
+            "workflow_manager.aws_event_bridge.event", level="ERROR"
+        ) as logs:
+            with self.assertRaises(EventBridgePublishError):
+                emit_wrsc_api_event(self.build_event())
+
+        self.assertIn("wrsc-event-id", " ".join(logs.output))
+        self.assertIn("InternalFailure", " ".join(logs.output))
+
+    @patch.dict(os.environ, {"EVENT_BUS_NAME": "test-event-bus"})
+    @patch("workflow_manager.aws_event_bridge.event.libeb.emit_event")
+    def test_emit_wrsc_api_event_reraises_sdk_exception(self, mock_emit_event):
+        mock_emit_event.side_effect = RuntimeError("network unavailable")
+
+        with self.assertLogs(
+            "workflow_manager.aws_event_bridge.event", level="ERROR"
+        ) as logs:
+            with self.assertRaisesRegex(RuntimeError, "network unavailable"):
+                emit_wrsc_api_event(self.build_event(), attempt_count=3)
+
+        logged = " ".join(logs.output)
+        self.assertIn("wrsc-event-id", logged)
+        self.assertIn("attempt=3", logged)

--- a/app/workflow_manager/tests/test_state_viewset.py
+++ b/app/workflow_manager/tests/test_state_viewset.py
@@ -131,7 +131,7 @@ class StateViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, 500)
         data = response.json()
         self.assertIn("rolled back", data["detail"])
-        self.assertIn("correlation_id", data)
+        self.assertIn("correlationId", data)
         self.assertFalse(
             State.objects.filter(
                 workflow_run=self.wfr_failed,

--- a/app/workflow_manager/tests/test_state_viewset.py
+++ b/app/workflow_manager/tests/test_state_viewset.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
+from django.db import DatabaseError
 from django.utils.timezone import make_aware
 
 from workflow_manager.models import (
@@ -111,6 +112,33 @@ class StateViewSetTestCase(TestCase):
             ).exists()
         )
         mock_emit_wrsc.assert_called_once()
+
+    @patch(
+        "workflow_manager.viewsets.state.StateViewSet.create_state_and_emit_wrsc",
+        side_effect=DatabaseError("database unavailable"),
+    )
+    def test_create_state_database_failure_returns_error_and_rolls_back_state(
+        self, mock_create_state_and_emit_wrsc
+    ):
+        url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/"
+
+        response = self.client.post(
+            url,
+            data={"status": "RESOLVED", "comment": "resolved ok"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 500)
+        data = response.json()
+        self.assertIn("rolled back", data["detail"])
+        self.assertIn("database unavailable", data["error"])
+        self.assertFalse(
+            State.objects.filter(
+                workflow_run=self.wfr_failed,
+                status="RESOLVED",
+            ).exists()
+        )
+        mock_create_state_and_emit_wrsc.assert_called_once()
 
     @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
     def test_create_state_rejects_invalid_transition_failed_to_deprecated(
@@ -247,6 +275,38 @@ class StateViewSetTestCase(TestCase):
         state_deprecated.refresh_from_db()
         self.assertEqual(state_deprecated.comment, "new")
 
+    def test_update_prefetched_objects_cache_invalidation_runs_with_patched_get_object(
+        self,
+    ):
+        """
+        Keep direct coverage on the cache invalidation assignment itself.
+        This branch only runs when get_object() returns an instance that was
+        previously fetched with prefetch_related().
+        """
+        from workflow_manager.viewsets.state import StateViewSet
+
+        viewset = StateViewSet()
+        request = MagicMock()
+        request.data = {"comment": "new patched"}
+        viewset.get_success_headers = MagicMock(return_value={})
+
+        state_deprecated = StateFactory(
+            workflow_run=self.wfr_failed,
+            status="DEPRECATED",
+            timestamp=make_aware(datetime.now() + timedelta(hours=21)),
+            comment="old",
+        )
+        state_deprecated._prefetched_objects_cache = {"states": [self.state_ready]}
+        state_deprecated.save = MagicMock()
+
+        with patch.object(viewset, "get_object", return_value=state_deprecated):
+            response = viewset.update(request, partial=True)
+
+        self.assertEqual(response.status_code, 200)
+        state_deprecated.save.assert_called_once_with(update_fields=["comment"])
+        self.assertEqual(state_deprecated._prefetched_objects_cache, {})
+        self.assertEqual(state_deprecated.comment, "new patched")
+
     @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
     def test_batch_state_transition_success_returns_summary(self, mock_emit_wrsc):
         response = self.client.post(
@@ -337,6 +397,42 @@ class StateViewSetTestCase(TestCase):
             ).exists()
         )
         self.assertEqual(mock_emit_wrsc.call_count, 2)
+
+    @patch(
+        "workflow_manager.viewsets.state.WorkflowRunBatchStateTransitionViewSet.create_state_and_emit_wrsc",
+        side_effect=DatabaseError("database unavailable"),
+    )
+    def test_batch_state_transition_database_failure_returns_failure_response(
+        self, mock_create_state_and_emit_wrsc
+    ):
+        response = self.client.post(
+            self.batch_endpoint,
+            data={
+                "workflowrun_orcabus_ids": [self.wfr_succeeded.orcabus_id],
+                "status": "DEPRECATED",
+                "comment": "bulk deprecated",
+            },
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 502)
+        data = response.json()
+        self.assertEqual(data["createdCount"], 0)
+        self.assertEqual(data["failedCount"], 1)
+        self.assertEqual(
+            data["failures"][0]["workflowrunOrcabusId"],
+            self.wfr_succeeded.orcabus_id,
+        )
+        self.assertEqual(data["failures"][0]["reason"], "STATE_CREATION_FAILED")
+        self.assertIn("database unavailable", data["failures"][0]["error"])
+        self.assertFalse(
+            State.objects.filter(
+                workflow_run=self.wfr_succeeded,
+                status="DEPRECATED",
+                comment="bulk deprecated",
+            ).exists()
+        )
+        mock_create_state_and_emit_wrsc.assert_called_once()
 
     @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
     def test_batch_state_transition_returns_partial_success_for_invalid_item(

--- a/app/workflow_manager/tests/test_state_viewset.py
+++ b/app/workflow_manager/tests/test_state_viewset.py
@@ -131,7 +131,7 @@ class StateViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, 500)
         data = response.json()
         self.assertIn("rolled back", data["detail"])
-        self.assertIn("database unavailable", data["error"])
+        self.assertIn("correlation_id", data)
         self.assertFalse(
             State.objects.filter(
                 workflow_run=self.wfr_failed,
@@ -415,7 +415,7 @@ class StateViewSetTestCase(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 502)
+        self.assertEqual(response.status_code, 500)
         data = response.json()
         self.assertEqual(data["createdCount"], 0)
         self.assertEqual(data["failedCount"], 1)
@@ -424,7 +424,7 @@ class StateViewSetTestCase(TestCase):
             self.wfr_succeeded.orcabus_id,
         )
         self.assertEqual(data["failures"][0]["reason"], "STATE_CREATION_FAILED")
-        self.assertIn("database unavailable", data["failures"][0]["error"])
+        self.assertNotIn("error", data["failures"][0])
         self.assertFalse(
             State.objects.filter(
                 workflow_run=self.wfr_succeeded,

--- a/app/workflow_manager/tests/test_state_viewset.py
+++ b/app/workflow_manager/tests/test_state_viewset.py
@@ -1,10 +1,14 @@
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 from django.utils.timezone import make_aware
 
-from workflow_manager.models import State, Workflow, WorkflowRun
+from workflow_manager.models import (
+    State,
+    Workflow,
+    WorkflowRun,
+)
 from workflow_manager.tests.factories import StateFactory, WorkflowRunFactory
 from workflow_manager.tests.fixtures.sim_workflow import TestData
 from workflow_manager.urls.base import api_base
@@ -53,7 +57,8 @@ class StateViewSetTestCase(TestCase):
             "status and comment fields are required", response.json()["detail"]
         )
 
-    def test_create_state_valid_transition_failed_to_resolved(self):
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_create_state_valid_transition_failed_to_resolved(self, mock_emit_wrsc):
         url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/"
         response = self.client.post(
             url,
@@ -64,8 +69,53 @@ class StateViewSetTestCase(TestCase):
         data = response.json()
         self.assertEqual(data["status"], "RESOLVED")
         self.assertEqual(data["comment"], "resolved ok")
+        mock_emit_wrsc.assert_called_once()
+        wrsc_event = mock_emit_wrsc.call_args.args[0]
+        self.assertEqual(wrsc_event["status"], "RESOLVED")
+        self.assertEqual(wrsc_event["orcabusId"], self.wfr_failed.orcabus_id)
+        self.assertEqual(wrsc_event["workflow"]["orcabusId"], self.wf.orcabus_id)
+        self.assertNotIn("payload", wrsc_event)
 
-    def test_create_state_rejects_invalid_transition_failed_to_deprecated(self):
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_create_state_emits_wrsc_inside_api_transaction(self, mock_emit_wrsc):
+        url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/"
+
+        response = self.client.post(
+            url,
+            data={"status": "RESOLVED", "comment": "resolved ok"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(mock_emit_wrsc.call_count, 1)
+
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_create_state_publish_failure_returns_error_and_rolls_back_state(
+        self, mock_emit_wrsc
+    ):
+        mock_emit_wrsc.side_effect = RuntimeError("event bus unavailable")
+        url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/"
+
+        response = self.client.post(
+            url,
+            data={"status": "RESOLVED", "comment": "resolved ok"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 502)
+        self.assertIn("rolled back", response.json()["detail"])
+        self.assertFalse(
+            State.objects.filter(
+                workflow_run=self.wfr_failed,
+                status="RESOLVED",
+            ).exists()
+        )
+        mock_emit_wrsc.assert_called_once()
+
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_create_state_rejects_invalid_transition_failed_to_deprecated(
+        self, mock_emit_wrsc
+    ):
         url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/"
         response = self.client.post(
             url,
@@ -74,6 +124,7 @@ class StateViewSetTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn("Invalid state request", response.json()["detail"])
+        mock_emit_wrsc.assert_not_called()
 
     def test_create_state_rejects_non_deprecated_when_no_latest_state(self):
         url = f"{self.endpoint}/{self.wfr_empty.orcabus_id}/state/"
@@ -88,7 +139,8 @@ class StateViewSetTestCase(TestCase):
             response.json()["detail"],
         )
 
-    def test_create_state_allows_deprecated_when_no_latest_state(self):
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_create_state_allows_deprecated_when_no_latest_state(self, mock_emit_wrsc):
         url = f"{self.endpoint}/{self.wfr_empty.orcabus_id}/state/"
         response = self.client.post(
             url,
@@ -98,6 +150,7 @@ class StateViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, 201)
         data = response.json()
         self.assertEqual(data["status"], "DEPRECATED")
+        mock_emit_wrsc.assert_called_once()
 
     def test_update_state_comment_requires_comment_field(self):
         url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/{self.state_ready.orcabus_id}/"
@@ -117,7 +170,8 @@ class StateViewSetTestCase(TestCase):
             "Invalid state status to update comment.", response.json()["detail"]
         )
 
-    def test_update_state_comment_success(self):
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_update_state_comment_success(self, mock_emit_wrsc):
         state_deprecated = StateFactory(
             workflow_run=self.wfr_failed,
             status="DEPRECATED",
@@ -133,6 +187,7 @@ class StateViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["comment"], "updated")
+        mock_emit_wrsc.assert_not_called()
 
     def test_is_valid_next_state_current_status_none_only_allows_deprecated(self):
         from workflow_manager.viewsets.state import StateViewSet
@@ -192,7 +247,8 @@ class StateViewSetTestCase(TestCase):
         state_deprecated.refresh_from_db()
         self.assertEqual(state_deprecated.comment, "new")
 
-    def test_batch_state_transition_success_returns_summary(self):
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_batch_state_transition_success_returns_summary(self, mock_emit_wrsc):
         response = self.client.post(
             self.batch_endpoint,
             data={
@@ -208,6 +264,7 @@ class StateViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, 201)
         data = response.json()
         self.assertEqual(data["createdCount"], 2)
+        self.assertEqual(data["failedCount"], 0)
         self.assertCountEqual(
             data["workflowrunOrcabusIds"],
             [self.wfr_succeeded.orcabus_id, self.wfr_empty.orcabus_id],
@@ -219,6 +276,13 @@ class StateViewSetTestCase(TestCase):
                 comment="bulk deprecated",
             ).exists()
         )
+        self.assertEqual(mock_emit_wrsc.call_count, 2)
+        wrsc_events = [call.args[0] for call in mock_emit_wrsc.call_args_list]
+        self.assertTrue(all("payload" not in event for event in wrsc_events))
+        self.assertCountEqual(
+            [event["orcabusId"] for event in wrsc_events],
+            [self.wfr_succeeded.orcabus_id, self.wfr_empty.orcabus_id],
+        )
         self.assertTrue(
             State.objects.filter(
                 workflow_run=self.wfr_empty,
@@ -227,7 +291,57 @@ class StateViewSetTestCase(TestCase):
             ).exists()
         )
 
-    def test_batch_state_transition_rejects_when_any_transition_invalid(self):
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_batch_state_transition_rolls_back_only_failed_emit_item(
+        self, mock_emit_wrsc
+    ):
+        mock_emit_wrsc.side_effect = [
+            {"FailedEntryCount": 0, "Entries": [{}]},
+            RuntimeError("event bus unavailable"),
+        ]
+        response = self.client.post(
+            self.batch_endpoint,
+            data={
+                "workflowrun_orcabus_ids": [
+                    self.wfr_succeeded.orcabus_id,
+                    self.wfr_empty.orcabus_id,
+                ],
+                "status": "DEPRECATED",
+                "comment": "bulk deprecated",
+            },
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 207)
+        data = response.json()
+        self.assertEqual(data["createdCount"], 1)
+        self.assertEqual(data["failedCount"], 1)
+        self.assertEqual(data["workflowrunOrcabusIds"], [self.wfr_succeeded.orcabus_id])
+        self.assertEqual(
+            data["failures"][0]["workflowrunOrcabusId"],
+            self.wfr_empty.orcabus_id,
+        )
+        self.assertEqual(data["failures"][0]["reason"], "WRSC_EMIT_FAILED")
+        self.assertTrue(
+            State.objects.filter(
+                workflow_run=self.wfr_succeeded,
+                status="DEPRECATED",
+                comment="bulk deprecated",
+            ).exists()
+        )
+        self.assertFalse(
+            State.objects.filter(
+                workflow_run=self.wfr_empty,
+                status="DEPRECATED",
+                comment="bulk deprecated",
+            ).exists()
+        )
+        self.assertEqual(mock_emit_wrsc.call_count, 2)
+
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_batch_state_transition_returns_partial_success_for_invalid_item(
+        self, mock_emit_wrsc
+    ):
         response = self.client.post(
             self.batch_endpoint,
             data={
@@ -240,9 +354,17 @@ class StateViewSetTestCase(TestCase):
             },
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid state request", response.json()["detail"])
-        self.assertFalse(
+        self.assertEqual(response.status_code, 207)
+        data = response.json()
+        self.assertEqual(data["createdCount"], 1)
+        self.assertEqual(data["failedCount"], 1)
+        self.assertEqual(data["workflowrunOrcabusIds"], [self.wfr_failed.orcabus_id])
+        self.assertEqual(
+            data["failures"][0]["workflowrunOrcabusId"],
+            self.wfr_succeeded.orcabus_id,
+        )
+        self.assertEqual(data["failures"][0]["reason"], "INVALID_TRANSITION")
+        self.assertTrue(
             State.objects.filter(
                 workflow_run=self.wfr_failed,
                 status="RESOLVED",
@@ -256,6 +378,7 @@ class StateViewSetTestCase(TestCase):
                 comment="bulk resolve",
             ).exists()
         )
+        mock_emit_wrsc.assert_called_once()
 
     def test_batch_state_transition_requires_fields(self):
         response = self.client.post(
@@ -274,10 +397,17 @@ class StateViewSetTestCase(TestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 400)
-        self.assertIn("not found", response.json()["detail"].lower())
+        data = response.json()
+        self.assertEqual(data["createdCount"], 0)
+        self.assertEqual(data["failedCount"], 1)
+        self.assertEqual(
+            data["failures"][0]["workflowrunOrcabusId"], "wfr.non-existing-id"
+        )
+        self.assertEqual(data["failures"][0]["reason"], "NOT_FOUND")
 
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
     def test_batch_state_transition_accepts_ids_without_prefix_and_returns_prefixed_ids(
-        self,
+        self, mock_emit_wrsc
     ):
         response = self.client.post(
             self.batch_endpoint,
@@ -297,8 +427,10 @@ class StateViewSetTestCase(TestCase):
             data["workflowrunOrcabusIds"],
             [self.wfr_succeeded.orcabus_id, self.wfr_empty.orcabus_id],
         )
+        self.assertEqual(mock_emit_wrsc.call_count, 2)
 
-    def test_batch_state_transition_accepts_csv_orcabus_ids(self):
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_batch_state_transition_accepts_csv_orcabus_ids(self, mock_emit_wrsc):
         response = self.client.post(
             self.batch_endpoint,
             data={
@@ -318,9 +450,11 @@ class StateViewSetTestCase(TestCase):
             data["workflowrunOrcabusIds"],
             [self.wfr_succeeded.orcabus_id, self.wfr_empty.orcabus_id],
         )
+        self.assertEqual(mock_emit_wrsc.call_count, 2)
 
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
     def test_batch_state_transition_accepts_form_urlencoded_camelcase_csv_orcabus_ids(
-        self,
+        self, mock_emit_wrsc
     ):
         response = self.client.post(
             self.batch_endpoint,
@@ -339,3 +473,4 @@ class StateViewSetTestCase(TestCase):
             data["workflowrunOrcabusIds"],
             [self.wfr_succeeded.orcabus_id, self.wfr_empty.orcabus_id],
         )
+        self.assertEqual(mock_emit_wrsc.call_count, 2)

--- a/app/workflow_manager/viewsets/state.py
+++ b/app/workflow_manager/viewsets/state.py
@@ -1,13 +1,19 @@
+import logging
+
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from drf_spectacular.types import OpenApiTypes
 from rest_framework.decorators import action
 from rest_framework import mixins, status
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
-from django.db import transaction
+from django.db import DatabaseError, transaction
 from django.utils import timezone
 
+from workflow_manager.aws_event_bridge.event import emit_wrsc_api_event
 from workflow_manager.models import State, WorkflowRun
+from workflow_manager_proc.services.workflow_run import (
+    map_workflow_run_new_state_to_wrsc,
+)
 from workflow_manager.serializers.state import (
     StateSerializer,
     StateCreateRequestSerializer,
@@ -15,6 +21,8 @@ from workflow_manager.serializers.state import (
     StateBatchTransitionRequestSerializer,
     StateBatchTransitionResponseSerializer,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class StateTransitionValidationMixin:
@@ -85,6 +93,62 @@ class StateTransitionValidationMixin:
             return current_status_upper in allowed_states
 
         return False
+
+    @staticmethod
+    def create_state_and_emit_wrsc(
+        workflow_run: WorkflowRun,
+        request_status: str,
+        request_comment: str,
+    ) -> tuple[State, dict]:
+        """Create a manual state and emit its WRSC event in the caller's transaction."""
+        logger.info(
+            "Creating manual workflow-run state: workflow_run_id=%s status=%s",
+            workflow_run.orcabus_id,
+            request_status,
+        )
+        instance = State.objects.create(
+            workflow_run=workflow_run,
+            status=request_status,
+            timestamp=timezone.now(),
+            comment=request_comment,
+        )
+        logger.info(
+            "Manual workflow-run state created: workflow_run_id=%s state_id=%s status=%s",
+            workflow_run.orcabus_id,
+            instance.orcabus_id,
+            request_status,
+        )
+
+        wrsc_event = map_workflow_run_new_state_to_wrsc(
+            workflow_run,
+            instance,
+        ).model_dump(mode="json", exclude_none=True)
+        wrsc_event.pop("payload", None)
+        logger.info(
+            "Manual WRSC event built: workflow_run_id=%s state_id=%s event_id=%s status=%s",
+            workflow_run.orcabus_id,
+            instance.orcabus_id,
+            wrsc_event.get("id"),
+            request_status,
+        )
+
+        emit_wrsc_api_event(wrsc_event)
+        logger.info(
+            "Manual WRSC event emitted: workflow_run_id=%s state_id=%s event_id=%s status=%s",
+            workflow_run.orcabus_id,
+            instance.orcabus_id,
+            wrsc_event.get("id"),
+            request_status,
+        )
+        return instance, wrsc_event
+
+    @staticmethod
+    def _failure_response_status(failures: list[dict]) -> int:
+        """Choose the most helpful HTTP status when no batch item succeeds."""
+        client_failure_reasons = {"NOT_FOUND", "INVALID_TRANSITION"}
+        if all(failure.get("reason") in client_failure_reasons for failure in failures):
+            return status.HTTP_400_BAD_REQUEST
+        return status.HTTP_502_BAD_GATEWAY
 
 
 @extend_schema_view(
@@ -160,6 +224,11 @@ class StateViewSet(
         # Handle case when there's no latest state - only allow DEPRECATED
         if not latest_state:
             if request_status != "DEPRECATED":
+                logger.warning(
+                    "Manual state transition validation failed: workflow_run_id=%s requested_status=%s latest_status=None",
+                    wfr_orcabus_id,
+                    request_status,
+                )
                 return Response(
                     {
                         "detail": "No state found for workflow run '{}'. Only DEPRECATED is allowed when there are no states.".format(
@@ -173,6 +242,12 @@ class StateViewSet(
             latest_status = latest_state.status
             # check if the state status is valid
             if not self.is_valid_next_state(latest_status, request_status):
+                logger.warning(
+                    "Manual state transition validation failed: workflow_run_id=%s requested_status=%s latest_status=%s",
+                    wfr_orcabus_id,
+                    request_status,
+                    latest_status,
+                )
                 return Response(
                     {
                         "detail": "Invalid state request. Can't add state '{}' to '{}'".format(
@@ -182,15 +257,55 @@ class StateViewSet(
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-        instance = State.objects.create(
-            workflow_run=workflow_run,
-            status=request_status,
-            timestamp=timezone.now(),
-            comment=request_comment,
+        logger.info(
+            "Manual state transition validated: workflow_run_id=%s requested_status=%s latest_status=%s",
+            wfr_orcabus_id,
+            request_status,
+            latest_status,
         )
+
+        try:
+            with transaction.atomic():
+                instance, _ = self.create_state_and_emit_wrsc(
+                    workflow_run,
+                    request_status,
+                    request_comment,
+                )
+        except DatabaseError as exc:
+            logger.exception(
+                "Manual state transition failed during database operation and was rolled back: workflow_run_id=%s requested_status=%s",
+                wfr_orcabus_id,
+                request_status,
+            )
+            return Response(
+                {
+                    "detail": "Failed to create workflow-run state. The operation was rolled back.",
+                    "error": str(exc),
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Manual state transition failed while emitting WRSC event and was rolled back: workflow_run_id=%s requested_status=%s",
+                wfr_orcabus_id,
+                request_status,
+            )
+            return Response(
+                {
+                    "detail": "Failed to create workflow-run state and emit WRSC event. The operation was rolled back.",
+                    "error": str(exc),
+                },
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
 
         data = StateSerializer(instance).data
         headers = self.get_success_headers(data)
+        logger.info(
+            "Manual state transition completed: workflow_run_id=%s state_id=%s status=%s",
+            wfr_orcabus_id,
+            instance.orcabus_id,
+            request_status,
+        )
         return Response(data, status=status.HTTP_201_CREATED, headers=headers)
 
     def update(self, request, *args, **kwargs):
@@ -261,45 +376,122 @@ class WorkflowRunBatchStateTransitionViewSet(
             self.normalize_workflowrun_orcabus_id(wfr.orcabus_id): wfr
             for wfr in workflow_runs
         }
-        missing_ids = [
-            raw_id
-            for raw_id, normalized_id in zip(workflowrun_orcabus_ids, normalized_ids)
-            if normalized_id not in workflow_runs_by_normalized_id
-        ]
-        if missing_ids:
-            return Response(
-                {"detail": f"Workflow run(s) not found: {', '.join(missing_ids)}"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
 
-        for wfr in workflow_runs:
+        created_workflowrun_ids = []
+        failures = []
+
+        for raw_id, normalized_id in zip(workflowrun_orcabus_ids, normalized_ids):
+            wfr = workflow_runs_by_normalized_id.get(normalized_id)
+            if not wfr:
+                logger.warning(
+                    "Batch manual state transition skipped missing workflow run: workflow_run_id=%s requested_status=%s",
+                    raw_id,
+                    request_status,
+                )
+                failures.append(
+                    {
+                        "workflowrun_orcabus_id": raw_id,
+                        "reason": "NOT_FOUND",
+                        "detail": "Workflow run not found.",
+                    }
+                )
+                continue
+
             latest_state = wfr.get_latest_state()
             latest_status = latest_state.status if latest_state else None
             if not self.is_valid_next_state(latest_status, request_status):
-                return Response(
+                logger.warning(
+                    "Batch manual state transition validation failed: workflow_run_id=%s requested_status=%s latest_status=%s",
+                    wfr.orcabus_id,
+                    request_status,
+                    latest_status,
+                )
+                failures.append(
                     {
+                        "workflowrun_orcabus_id": wfr.orcabus_id,
+                        "reason": "INVALID_TRANSITION",
                         "detail": "Invalid state request. Can't add state '{}' to workflow run '{}' from '{}'".format(
                             request_status,
                             wfr.orcabus_id,
                             latest_status,
-                        )
+                        ),
                     },
-                    status=status.HTTP_400_BAD_REQUEST,
                 )
+                continue
 
-        with transaction.atomic():
-            for wfr in workflow_runs:
-                State.objects.create(
-                    workflow_run=wfr,
-                    status=request_status,
-                    timestamp=timezone.now(),
-                    comment=request_comment,
+            logger.info(
+                "Batch manual state transition validated: workflow_run_id=%s requested_status=%s latest_status=%s",
+                wfr.orcabus_id,
+                request_status,
+                latest_status,
+            )
+            try:
+                with transaction.atomic():
+                    state_instance, _ = self.create_state_and_emit_wrsc(
+                        wfr,
+                        request_status,
+                        request_comment,
+                    )
+            except DatabaseError as exc:
+                logger.exception(
+                    "Batch manual state transition failed during database operation and was rolled back: workflow_run_id=%s requested_status=%s",
+                    wfr.orcabus_id,
+                    request_status,
                 )
+                failures.append(
+                    {
+                        "workflowrun_orcabus_id": wfr.orcabus_id,
+                        "reason": "STATE_CREATION_FAILED",
+                        "detail": "Failed to create workflow-run state. The operation was rolled back.",
+                        "error": str(exc),
+                    }
+                )
+                continue
+            except Exception as exc:
+                logger.exception(
+                    "Batch manual state transition failed while emitting WRSC event and was rolled back: workflow_run_id=%s requested_status=%s",
+                    wfr.orcabus_id,
+                    request_status,
+                )
+                failures.append(
+                    {
+                        "workflowrun_orcabus_id": wfr.orcabus_id,
+                        "reason": "WRSC_EMIT_FAILED",
+                        "detail": "Failed to create workflow-run state and emit WRSC event. The operation was rolled back.",
+                        "error": str(exc),
+                    }
+                )
+                continue
+
+            created_workflowrun_ids.append(wfr.orcabus_id)
+            logger.info(
+                "Batch manual state transition completed: workflow_run_id=%s state_id=%s status=%s",
+                wfr.orcabus_id,
+                state_instance.orcabus_id,
+                request_status,
+            )
+
+        response_status = status.HTTP_201_CREATED
+        if failures:
+            response_status = (
+                status.HTTP_207_MULTI_STATUS
+                if created_workflowrun_ids
+                else self._failure_response_status(failures)
+            )
 
         summary = StateBatchTransitionResponseSerializer(
             instance={
-                "created_count": len(workflow_runs),
-                "workflowrun_orcabus_ids": [wfr.orcabus_id for wfr in workflow_runs],
+                "created_count": len(created_workflowrun_ids),
+                "workflowrun_orcabus_ids": created_workflowrun_ids,
+                "failed_count": len(failures),
+                "failures": failures,
             }
         )
-        return Response(summary.data, status=status.HTTP_201_CREATED)
+        logger.info(
+            "Batch manual state transition finished: requested_status=%s created_count=%s failed_count=%s response_status=%s",
+            request_status,
+            len(created_workflowrun_ids),
+            len(failures),
+            response_status,
+        )
+        return Response(summary.data, status=response_status)

--- a/app/workflow_manager/viewsets/state.py
+++ b/app/workflow_manager/viewsets/state.py
@@ -144,11 +144,19 @@ class StateTransitionValidationMixin:
 
     @staticmethod
     def _failure_response_status(failures: list[dict]) -> int:
-        """Choose the most helpful HTTP status when no batch item succeeds."""
+        """Choose the most helpful HTTP status when no batch item succeeds.
+
+        - All client-side reasons (NOT_FOUND, INVALID_TRANSITION) → 400
+        - Any upstream/WRSC emission failure → 502
+        - Any database failure (no WRSC failure) → 500
+        """
         client_failure_reasons = {"NOT_FOUND", "INVALID_TRANSITION"}
-        if all(failure.get("reason") in client_failure_reasons for failure in failures):
+        reasons = {failure.get("reason") for failure in failures}
+        if reasons <= client_failure_reasons:
             return status.HTTP_400_BAD_REQUEST
-        return status.HTTP_502_BAD_GATEWAY
+        if "WRSC_EMIT_FAILED" in reasons:
+            return status.HTTP_502_BAD_GATEWAY
+        return status.HTTP_500_INTERNAL_SERVER_ERROR
 
 
 @extend_schema_view(
@@ -280,7 +288,7 @@ class StateViewSet(
             return Response(
                 {
                     "detail": "Failed to create workflow-run state. The operation was rolled back.",
-                    "error": str(exc),
+                    "correlation_id": f"{wfr_orcabus_id}:{request_status}",
                 },
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
@@ -293,7 +301,7 @@ class StateViewSet(
             return Response(
                 {
                     "detail": "Failed to create workflow-run state and emit WRSC event. The operation was rolled back.",
-                    "error": str(exc),
+                    "correlation_id": f"{wfr_orcabus_id}:{request_status}",
                 },
                 status=status.HTTP_502_BAD_GATEWAY,
             )
@@ -443,7 +451,6 @@ class WorkflowRunBatchStateTransitionViewSet(
                         "workflowrun_orcabus_id": wfr.orcabus_id,
                         "reason": "STATE_CREATION_FAILED",
                         "detail": "Failed to create workflow-run state. The operation was rolled back.",
-                        "error": str(exc),
                     }
                 )
                 continue
@@ -458,7 +465,6 @@ class WorkflowRunBatchStateTransitionViewSet(
                         "workflowrun_orcabus_id": wfr.orcabus_id,
                         "reason": "WRSC_EMIT_FAILED",
                         "detail": "Failed to create workflow-run state and emit WRSC event. The operation was rolled back.",
-                        "error": str(exc),
                     }
                 )
                 continue

--- a/infrastructure/stage/stack.ts
+++ b/infrastructure/stage/stack.ts
@@ -183,7 +183,8 @@ export class WorkflowManagerStack extends GitStack {
       routeKey: HttpRouteKey.with('/{proxy+}', HttpMethod.DELETE),
     });
 
-    // Route and permission for rerun cases where it needs to put event to mainBus
+    // Route and permission for API cases where it needs to put events to mainBus
+    // (e.g. rerun WRU and manual state-transition WRSC events).
     this.mainBus.grantPutEventsTo(apiFn);
     new HttpRoute(this, 'PostRerunHttpRoute', {
       httpApi: httpApi,


### PR DESCRIPTION
Resolve https://github.com/OrcaBus/service-workflow-manager/issues/160,  and related with https://github.com/OrcaBus/service-workflow-manager/issues/163, and https://github.com/OrcaBus/service-workflow-manager/pull/169#issuecomment-4769041936

## Summary

Emit WorkflowRunStateChange (WRSC) events after manual workflow-run state transitions through the state transition API.

Manual single and batch state creation now create the new State and emit the WRSC event within a transaction. If WRSC emission fails, the state creation is rolled back and the API returns an error so the user can retry.

## Changes
1. Added `emit_wrsc_api_event()` alongside the existing WRU API event emitter.

- Validates events with WorkflowRunStateChange.
- Emits via libumccr.aws.libeb.emit_event().
- Uses source orcabus.workflowmanager.
- Uses detail type WorkflowRunStateChange.
- Serializes with exclude_none=True, so optional payload is omitted.
- Detects EventBridge FailedEntryCount > 0 and raises an error with AWS error details.
- Logs event ID, workflow-run ID, status, attempt count, and failure details.

2. Updated single manual state creation.

- Validates the requested state transition.
- Creates the new state inside transaction.atomic().
- Builds WRSC from the new state and workflow run.
- Emits the WRSC event before committing.
- Rolls back the state if DB creation or WRSC emission fails.
- Returns an API error on failure.

3. Updated batch manual state transition.

- Processes each workflow run independently inside its own transaction.atomic().
- Allows partial success.
- Rolls back only the failed workflow-run transition.
- Returns:
  - 201 when all transitions succeed.
  - 207 when some transitions succeed and some fail.
  - 400 when no transitions succeed due to client-side issues such as missing workflow run or invalid transition.
  - 502 when no transitions succeed due to WRSC emission failures.
- Response now includes createdCount, workflowrunOrcabusIds, failedCount, and failures.

4. Added logging in state transition view logic for validation, state creation, WRSC creation/emission, success, and rollback failures.

## Notes

- PATCH/comment updates do not emit WRSC events.
- Invalid transitions do not create state records and do not emit events.
- The WRSC payload key is omitted, not emitted as null.