### PR TITLE
Improve Workflow Run State-Transition APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ fix:
 	@pnpm lint-fix
 
 audit-fix:
-	@pnpm audit --fix
+	@pnpm audit --fix override
 
 install:
 	@pnpm install --frozen-lockfile

--- a/app/workflow_manager/serializers/state.py
+++ b/app/workflow_manager/serializers/state.py
@@ -47,6 +47,23 @@ class StateTransitionRequestSerializer(serializers.Serializer):
     comment = serializers.CharField(required=True, allow_blank=False)
 
 
+class StateTransitionValidationErrorSerializer(serializers.Serializer):
+    """Field-level validation errors returned for an invalid transition request."""
+
+    workflowrun_orcabus_ids = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+    )
+    comment = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+    )
+    non_field_errors = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+    )
+
+
 class StateTransitionFailureSerializer(serializers.Serializer):
     workflowrun_orcabus_id = serializers.CharField()
     reason = serializers.CharField()

--- a/app/workflow_manager/serializers/state.py
+++ b/app/workflow_manager/serializers/state.py
@@ -23,16 +23,6 @@ class StateSerializer(StateBaseSerializer):
         fields = "__all__"
 
 
-class StateCreateRequestSerializer(serializers.Serializer):
-    """
-    Schema contract for POST /state.
-    Request accepts only `status` and `comment`.
-    """
-
-    status = serializers.CharField(required=True, allow_blank=False)
-    comment = serializers.CharField(required=True, allow_blank=False)
-
-
 class StateUpdateRequestSerializer(serializers.Serializer):
     """
     Schema contract for PATCH /state/{id}.
@@ -42,10 +32,11 @@ class StateUpdateRequestSerializer(serializers.Serializer):
     comment = serializers.CharField(required=True, allow_blank=False)
 
 
-class StateBatchTransitionRequestSerializer(serializers.Serializer):
+class StateTransitionRequestSerializer(serializers.Serializer):
     """
-    Schema contract for POST /workflowrun/state/batch-state-transition/.
-    Request body: workflowrun_orcabus_ids (list or CSV string), status, comment.
+    Schema contract for POST /workflowrun/state/{transition}/.
+    The endpoint determines the target state. The request body contains
+    workflowrunOrcabusIds (list or CSV string) and comment.
     """
 
     workflowrun_orcabus_ids = OrcabusIdListField(
@@ -53,20 +44,19 @@ class StateBatchTransitionRequestSerializer(serializers.Serializer):
         required=True,
         allow_empty=False,
     )
-    status = serializers.CharField(required=True, allow_blank=False)
     comment = serializers.CharField(required=True, allow_blank=False)
 
 
-class StateBatchTransitionFailureSerializer(serializers.Serializer):
+class StateTransitionFailureSerializer(serializers.Serializer):
     workflowrun_orcabus_id = serializers.CharField()
     reason = serializers.CharField()
     detail = serializers.CharField()
     error = serializers.CharField(required=False)
 
 
-class StateBatchTransitionResponseSerializer(serializers.Serializer):
+class StateTransitionResponseSerializer(serializers.Serializer):
     """
-    Schema contract for batch-state-transition responses.
+    Schema contract for workflow-run state transition responses.
     JSON responses use camelCase (createdCount, workflowrunOrcabusIds, failedCount).
     """
 
@@ -76,7 +66,7 @@ class StateBatchTransitionResponseSerializer(serializers.Serializer):
         allow_empty=True,
     )
     failed_count = serializers.IntegerField(default=0)
-    failures = StateBatchTransitionFailureSerializer(
+    failures = StateTransitionFailureSerializer(
         many=True,
         required=False,
     )

--- a/app/workflow_manager/tests/test_state_viewset.py
+++ b/app/workflow_manager/tests/test_state_viewset.py
@@ -17,7 +17,9 @@ from workflow_manager.urls.base import api_base
 
 class StateViewSetTestCase(TestCase):
     endpoint = f"/{api_base}workflowrun"
-    batch_endpoint = f"/{api_base}workflowrun/state/batch-state-transition/"
+    deprecate_endpoint = f"/{api_base}workflowrun/state/deprecate/"
+    resolve_endpoint = f"/{api_base}workflowrun/state/resolve/"
+    cancel_endpoint = f"/{api_base}workflowrun/state/cancel/"
 
     def setUp(self):
         TestData().create_primary()
@@ -43,33 +45,58 @@ class StateViewSetTestCase(TestCase):
         self.assertGreaterEqual(len(data), 1)
 
     def test_get_states_transition_validation_map_returns_200(self):
-        url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/get_states_transition_validation_map/"
+        url = f"{self.endpoint}/state/get_states_transition_validation_map/"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertIn("RESOLVED", data)
         self.assertIn("DEPRECATED", data)
 
-    def test_create_state_requires_status_and_comment_fields(self):
-        url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/"
-        response = self.client.post(url, data={}, content_type="application/json")
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(
-            "status and comment fields are required", response.json()["detail"]
-        )
+    def test_nested_states_transition_validation_map_route_is_not_available(self):
+        url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/get_states_transition_validation_map/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 405)
 
-    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
-    def test_create_state_valid_transition_failed_to_resolved(self, mock_emit_wrsc):
+    def test_generic_state_endpoint_no_longer_accepts_post(self):
         url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/"
         response = self.client.post(
             url,
-            data={"status": "RESOLVED", "comment": "resolved ok"},
+            data={"status": "RESOLVED", "comment": "old endpoint"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 405)
+
+    def test_resolve_requires_comment(self):
+        response = self.client.post(
+            self.resolve_endpoint,
+            data={"workflowrunOrcabusIds": [self.wfr_failed.orcabus_id]},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("comment", response.json())
+
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_resolve_transitions_failed_workflow_run(self, mock_emit_wrsc):
+        response = self.client.post(
+            self.resolve_endpoint,
+            data={
+                "workflowrunOrcabusIds": [self.wfr_failed.orcabus_id],
+                "comment": "resolved ok",
+            },
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 201)
         data = response.json()
-        self.assertEqual(data["status"], "RESOLVED")
-        self.assertEqual(data["comment"], "resolved ok")
+        self.assertEqual(data["createdCount"], 1)
+        self.assertEqual(data["failedCount"], 0)
+        self.assertEqual(data["workflowrunOrcabusIds"], [self.wfr_failed.orcabus_id])
+        self.assertTrue(
+            State.objects.filter(
+                workflow_run=self.wfr_failed,
+                status="RESOLVED",
+                comment="resolved ok",
+            ).exists()
+        )
         mock_emit_wrsc.assert_called_once()
         wrsc_event = mock_emit_wrsc.call_args.args[0]
         self.assertEqual(wrsc_event["status"], "RESOLVED")
@@ -78,33 +105,184 @@ class StateViewSetTestCase(TestCase):
         self.assertNotIn("payload", wrsc_event)
 
     @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
-    def test_create_state_emits_wrsc_inside_api_transaction(self, mock_emit_wrsc):
-        url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/"
+    def test_deprecate_transitions_succeeded_workflow_run(self, mock_emit_wrsc):
+        response = self.client.post(
+            self.deprecate_endpoint,
+            data={
+                "workflowrunOrcabusIds": [self.wfr_succeeded.orcabus_id],
+                "comment": "no longer needed",
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data["createdCount"], 1)
+        self.assertEqual(data["workflowrunOrcabusIds"], [self.wfr_succeeded.orcabus_id])
+        self.assertTrue(
+            State.objects.filter(
+                workflow_run=self.wfr_succeeded,
+                status="DEPRECATED",
+                comment="no longer needed",
+            ).exists()
+        )
+        mock_emit_wrsc.assert_called_once()
+        self.assertEqual(mock_emit_wrsc.call_args.args[0]["status"], "DEPRECATED")
+
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_deprecate_rejects_failed_workflow_run(self, mock_emit_wrsc):
+        response = self.client.post(
+            self.deprecate_endpoint,
+            data={
+                "workflowrunOrcabusIds": [self.wfr_failed.orcabus_id],
+                "comment": "should fail",
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertEqual(data["createdCount"], 0)
+        self.assertEqual(data["failedCount"], 1)
+        self.assertEqual(data["failures"][0]["reason"], "INVALID_TRANSITION")
+        mock_emit_wrsc.assert_not_called()
+
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_deprecate_preserves_no_source_state_behavior(self, mock_emit_wrsc):
+        response = self.client.post(
+            self.deprecate_endpoint,
+            data={
+                "workflowrunOrcabusIds": [self.wfr_empty.orcabus_id],
+                "comment": "deprecated first state",
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["createdCount"], 1)
+        self.assertTrue(
+            State.objects.filter(
+                workflow_run=self.wfr_empty,
+                status="DEPRECATED",
+                comment="deprecated first state",
+            ).exists()
+        )
+        mock_emit_wrsc.assert_called_once()
+
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_cancel_preserves_existing_allowed_source_states(self, mock_emit_wrsc):
+        source_statuses = [
+            "DRAFT",
+            "READY",
+            "SUBMITTED",
+            "RUNNABLE",
+            "STARTING",
+            "RUNNING",
+            "PAUSED",
+            "CANCELLED",
+        ]
+        workflow_runs = []
+        for index, source_status in enumerate(source_statuses):
+            workflow_run = WorkflowRunFactory(
+                workflow=self.wf,
+                portal_run_id=f"cancel-transient-{index}",
+            )
+            StateFactory(
+                workflow_run=workflow_run,
+                status=source_status,
+                timestamp=make_aware(datetime.now() + timedelta(hours=20)),
+            )
+            workflow_runs.append(workflow_run)
 
         response = self.client.post(
-            url,
-            data={"status": "RESOLVED", "comment": "resolved ok"},
+            self.cancel_endpoint,
+            data={
+                "workflowrunOrcabusIds": [
+                    workflow_run.orcabus_id for workflow_run in workflow_runs
+                ],
+                "comment": "cancel transient runs",
+            },
             content_type="application/json",
         )
 
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(mock_emit_wrsc.call_count, 1)
+        self.assertEqual(response.json()["createdCount"], len(source_statuses))
+        for workflow_run in workflow_runs:
+            self.assertTrue(
+                State.objects.filter(
+                    workflow_run=workflow_run,
+                    status="CANCELLED",
+                    comment="cancel transient runs",
+                ).exists()
+            )
+        self.assertEqual(mock_emit_wrsc.call_count, len(source_statuses))
+        self.assertTrue(
+            all(
+                call.args[0]["status"] == "ABORTED"
+                for call in mock_emit_wrsc.call_args_list
+            )
+        )
 
     @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
-    def test_create_state_publish_failure_returns_error_and_rolls_back_state(
-        self, mock_emit_wrsc
-    ):
-        mock_emit_wrsc.side_effect = RuntimeError("event bus unavailable")
-        url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/"
+    def test_cancel_rejects_existing_excluded_states(self, mock_emit_wrsc):
+        source_statuses = [
+            "SUCCEEDED",
+            "FAILED",
+            "ABORTED",
+            "RESOLVED",
+            "DEPRECATED",
+        ]
+        workflow_runs = []
+        for index, source_status in enumerate(source_statuses):
+            workflow_run = WorkflowRunFactory(
+                workflow=self.wf,
+                portal_run_id=f"cancel-terminal-{index}",
+            )
+            StateFactory(
+                workflow_run=workflow_run,
+                status=source_status,
+                timestamp=make_aware(datetime.now() + timedelta(hours=20)),
+            )
+            workflow_runs.append(workflow_run)
 
         response = self.client.post(
-            url,
-            data={"status": "RESOLVED", "comment": "resolved ok"},
+            self.cancel_endpoint,
+            data={
+                "workflowrunOrcabusIds": [
+                    workflow_run.orcabus_id for workflow_run in workflow_runs
+                ],
+                "comment": "should fail",
+            },
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertEqual(data["createdCount"], 0)
+        self.assertEqual(data["failedCount"], len(source_statuses))
+        self.assertTrue(
+            all(
+                failure["reason"] == "INVALID_TRANSITION"
+                for failure in data["failures"]
+            )
+        )
+        mock_emit_wrsc.assert_not_called()
+
+    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
+    def test_state_transition_wrsc_failure_rolls_back_state(self, mock_emit_wrsc):
+        mock_emit_wrsc.side_effect = RuntimeError("event bus unavailable")
+
+        response = self.client.post(
+            self.resolve_endpoint,
+            data={
+                "workflowrunOrcabusIds": [self.wfr_failed.orcabus_id],
+                "comment": "resolved ok",
+            },
             content_type="application/json",
         )
 
         self.assertEqual(response.status_code, 502)
-        self.assertIn("rolled back", response.json()["detail"])
+        data = response.json()
+        self.assertEqual(data["createdCount"], 0)
+        self.assertEqual(data["failedCount"], 1)
+        self.assertEqual(data["failures"][0]["reason"], "WRSC_EMIT_FAILED")
         self.assertFalse(
             State.objects.filter(
                 workflow_run=self.wfr_failed,
@@ -114,24 +292,26 @@ class StateViewSetTestCase(TestCase):
         mock_emit_wrsc.assert_called_once()
 
     @patch(
-        "workflow_manager.viewsets.state.StateViewSet.create_state_and_emit_wrsc",
+        "workflow_manager.viewsets.state.WorkflowRunStateTransitionViewSet.create_state_and_emit_wrsc",
         side_effect=DatabaseError("database unavailable"),
     )
-    def test_create_state_database_failure_returns_error_and_rolls_back_state(
+    def test_state_transition_database_failure_rolls_back_state(
         self, mock_create_state_and_emit_wrsc
     ):
-        url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/"
-
         response = self.client.post(
-            url,
-            data={"status": "RESOLVED", "comment": "resolved ok"},
+            self.resolve_endpoint,
+            data={
+                "workflowrunOrcabusIds": [self.wfr_failed.orcabus_id],
+                "comment": "resolved ok",
+            },
             content_type="application/json",
         )
 
         self.assertEqual(response.status_code, 500)
         data = response.json()
-        self.assertIn("rolled back", data["detail"])
-        self.assertIn("correlationId", data)
+        self.assertEqual(data["createdCount"], 0)
+        self.assertEqual(data["failedCount"], 1)
+        self.assertEqual(data["failures"][0]["reason"], "STATE_CREATION_FAILED")
         self.assertFalse(
             State.objects.filter(
                 workflow_run=self.wfr_failed,
@@ -140,45 +320,31 @@ class StateViewSetTestCase(TestCase):
         )
         mock_create_state_and_emit_wrsc.assert_called_once()
 
-    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
-    def test_create_state_rejects_invalid_transition_failed_to_deprecated(
-        self, mock_emit_wrsc
-    ):
-        url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/"
-        response = self.client.post(
-            url,
-            data={"status": "DEPRECATED", "comment": "should fail"},
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid state request", response.json()["detail"])
-        mock_emit_wrsc.assert_not_called()
+    def test_superseded_state_transition_routes_are_not_available(self):
+        detail_urls = [
+            f"{self.endpoint}/{self.wfr_failed.orcabus_id}/deprecate/",
+            f"{self.endpoint}/{self.wfr_failed.orcabus_id}/resolve/",
+            f"{self.endpoint}/{self.wfr_failed.orcabus_id}/cancel/",
+        ]
+        for url in detail_urls:
+            with self.subTest(url=url):
+                response = self.client.post(
+                    url,
+                    data={"comment": "old route"},
+                    content_type="application/json",
+                )
+                self.assertEqual(response.status_code, 404)
 
-    def test_create_state_rejects_non_deprecated_when_no_latest_state(self):
-        url = f"{self.endpoint}/{self.wfr_empty.orcabus_id}/state/"
         response = self.client.post(
-            url,
-            data={"status": "READY", "comment": "no latest state yet"},
+            f"/{api_base}workflowrun/state/batch-state-transition/",
+            data={
+                "workflowrunOrcabusIds": [self.wfr_failed.orcabus_id],
+                "status": "RESOLVED",
+                "comment": "old route",
+            },
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(
-            "Only DEPRECATED is allowed when there are no states",
-            response.json()["detail"],
-        )
-
-    @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
-    def test_create_state_allows_deprecated_when_no_latest_state(self, mock_emit_wrsc):
-        url = f"{self.endpoint}/{self.wfr_empty.orcabus_id}/state/"
-        response = self.client.post(
-            url,
-            data={"status": "DEPRECATED", "comment": "deprecated first state"},
-            content_type="application/json",
-        )
-        self.assertEqual(response.status_code, 201)
-        data = response.json()
-        self.assertEqual(data["status"], "DEPRECATED")
-        mock_emit_wrsc.assert_called_once()
+        self.assertEqual(response.status_code, 404)
 
     def test_update_state_comment_requires_comment_field(self):
         url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/{self.state_ready.orcabus_id}/"
@@ -257,7 +423,6 @@ class StateViewSetTestCase(TestCase):
         viewset = StateViewSet()
         request = MagicMock()
         request.data = {"comment": "new"}
-        viewset.get_success_headers = MagicMock(return_value={})
 
         state_deprecated = StateFactory(
             workflow_run=self.wfr_failed,
@@ -308,15 +473,14 @@ class StateViewSetTestCase(TestCase):
         self.assertEqual(state_deprecated.comment, "new patched")
 
     @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
-    def test_batch_state_transition_success_returns_summary(self, mock_emit_wrsc):
+    def test_state_transition_success_returns_summary(self, mock_emit_wrsc):
         response = self.client.post(
-            self.batch_endpoint,
+            self.deprecate_endpoint,
             data={
-                "workflowrun_orcabus_ids": [
+                "workflowrunOrcabusIds": [
                     self.wfr_succeeded.orcabus_id,
                     self.wfr_empty.orcabus_id,
                 ],
-                "status": "DEPRECATED",
                 "comment": "bulk deprecated",
             },
             content_type="application/json",
@@ -352,21 +516,18 @@ class StateViewSetTestCase(TestCase):
         )
 
     @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
-    def test_batch_state_transition_rolls_back_only_failed_emit_item(
-        self, mock_emit_wrsc
-    ):
+    def test_state_transition_rolls_back_only_failed_emit_item(self, mock_emit_wrsc):
         mock_emit_wrsc.side_effect = [
             {"FailedEntryCount": 0, "Entries": [{}]},
             RuntimeError("event bus unavailable"),
         ]
         response = self.client.post(
-            self.batch_endpoint,
+            self.deprecate_endpoint,
             data={
-                "workflowrun_orcabus_ids": [
+                "workflowrunOrcabusIds": [
                     self.wfr_succeeded.orcabus_id,
                     self.wfr_empty.orcabus_id,
                 ],
-                "status": "DEPRECATED",
                 "comment": "bulk deprecated",
             },
             content_type="application/json",
@@ -399,17 +560,16 @@ class StateViewSetTestCase(TestCase):
         self.assertEqual(mock_emit_wrsc.call_count, 2)
 
     @patch(
-        "workflow_manager.viewsets.state.WorkflowRunBatchStateTransitionViewSet.create_state_and_emit_wrsc",
+        "workflow_manager.viewsets.state.WorkflowRunStateTransitionViewSet.create_state_and_emit_wrsc",
         side_effect=DatabaseError("database unavailable"),
     )
-    def test_batch_state_transition_database_failure_returns_failure_response(
+    def test_state_transition_database_failure_returns_failure_response(
         self, mock_create_state_and_emit_wrsc
     ):
         response = self.client.post(
-            self.batch_endpoint,
+            self.deprecate_endpoint,
             data={
-                "workflowrun_orcabus_ids": [self.wfr_succeeded.orcabus_id],
-                "status": "DEPRECATED",
+                "workflowrunOrcabusIds": [self.wfr_succeeded.orcabus_id],
                 "comment": "bulk deprecated",
             },
             content_type="application/json",
@@ -435,17 +595,16 @@ class StateViewSetTestCase(TestCase):
         mock_create_state_and_emit_wrsc.assert_called_once()
 
     @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
-    def test_batch_state_transition_returns_partial_success_for_invalid_item(
+    def test_state_transition_returns_partial_success_for_invalid_item(
         self, mock_emit_wrsc
     ):
         response = self.client.post(
-            self.batch_endpoint,
+            self.resolve_endpoint,
             data={
-                "workflowrun_orcabus_ids": [
+                "workflowrunOrcabusIds": [
                     self.wfr_failed.orcabus_id,
                     self.wfr_succeeded.orcabus_id,
                 ],
-                "status": "RESOLVED",
                 "comment": "bulk resolve",
             },
             content_type="application/json",
@@ -476,18 +635,17 @@ class StateViewSetTestCase(TestCase):
         )
         mock_emit_wrsc.assert_called_once()
 
-    def test_batch_state_transition_requires_fields(self):
+    def test_state_transition_requires_fields(self):
         response = self.client.post(
-            self.batch_endpoint, data={}, content_type="application/json"
+            self.deprecate_endpoint, data={}, content_type="application/json"
         )
         self.assertEqual(response.status_code, 400)
 
-    def test_batch_state_transition_rejects_unknown_workflowrun(self):
+    def test_state_transition_rejects_unknown_workflowrun(self):
         response = self.client.post(
-            self.batch_endpoint,
+            self.deprecate_endpoint,
             data={
-                "workflowrun_orcabus_ids": ["wfr.non-existing-id"],
-                "status": "DEPRECATED",
+                "workflowrunOrcabusIds": ["wfr.non-existing-id"],
                 "comment": "bulk deprecated",
             },
             content_type="application/json",
@@ -502,17 +660,16 @@ class StateViewSetTestCase(TestCase):
         self.assertEqual(data["failures"][0]["reason"], "NOT_FOUND")
 
     @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
-    def test_batch_state_transition_accepts_ids_without_prefix_and_returns_prefixed_ids(
+    def test_state_transition_accepts_ids_without_prefix_and_returns_prefixed_ids(
         self, mock_emit_wrsc
     ):
         response = self.client.post(
-            self.batch_endpoint,
+            self.deprecate_endpoint,
             data={
-                "workflowrun_orcabus_ids": [
+                "workflowrunOrcabusIds": [
                     self.wfr_succeeded.orcabus_id.replace("wfr.", "", 1),
                     self.wfr_empty.orcabus_id.replace("wfr.", "", 1),
                 ],
-                "status": "DEPRECATED",
                 "comment": "bulk deprecated no prefix",
             },
             content_type="application/json",
@@ -526,15 +683,14 @@ class StateViewSetTestCase(TestCase):
         self.assertEqual(mock_emit_wrsc.call_count, 2)
 
     @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
-    def test_batch_state_transition_accepts_csv_orcabus_ids(self, mock_emit_wrsc):
+    def test_state_transition_accepts_csv_orcabus_ids(self, mock_emit_wrsc):
         response = self.client.post(
-            self.batch_endpoint,
+            self.deprecate_endpoint,
             data={
-                "workflowrun_orcabus_ids": "{},{}".format(
+                "workflowrunOrcabusIds": "{},{}".format(
                     self.wfr_succeeded.orcabus_id.replace("wfr.", "", 1),
                     self.wfr_empty.orcabus_id.replace("wfr.", "", 1),
                 ),
-                "status": "DEPRECATED",
                 "comment": "bulk deprecated csv ids",
             },
             content_type="application/json",
@@ -549,12 +705,12 @@ class StateViewSetTestCase(TestCase):
         self.assertEqual(mock_emit_wrsc.call_count, 2)
 
     @patch("workflow_manager.viewsets.state.emit_wrsc_api_event")
-    def test_batch_state_transition_accepts_form_urlencoded_camelcase_csv_orcabus_ids(
+    def test_state_transition_accepts_form_urlencoded_camelcase_csv_orcabus_ids(
         self, mock_emit_wrsc
     ):
         response = self.client.post(
-            self.batch_endpoint,
-            data="workflowrunOrcabusIds={}&status=Deprecated&comment=Second%20batch%20state%20transition.".format(
+            self.deprecate_endpoint,
+            data="workflowrunOrcabusIds={}&comment=Second%20state%20transition.".format(
                 "{},{}".format(
                     self.wfr_succeeded.orcabus_id.replace("wfr.", "", 1),
                     self.wfr_empty.orcabus_id.replace("wfr.", "", 1),

--- a/app/workflow_manager/tests/test_state_viewset.py
+++ b/app/workflow_manager/tests/test_state_viewset.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -51,6 +52,41 @@ class StateViewSetTestCase(TestCase):
         data = response.json()
         self.assertIn("RESOLVED", data)
         self.assertIn("DEPRECATED", data)
+        self.assertIn("CANCELLED", data["CANCELLED"]["excludedStates"])
+
+    def test_state_transition_openapi_documents_all_response_shapes(self):
+        response = self.client.get(
+            "/schema/openapi.json",
+            HTTP_ACCEPT="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        schema = json.loads(response.content)
+
+        expected_statuses = {"201", "207", "400", "500", "502"}
+        transition_paths = (
+            self.deprecate_endpoint,
+            self.resolve_endpoint,
+            self.cancel_endpoint,
+        )
+        for transition_path in transition_paths:
+            with self.subTest(transition_path=transition_path):
+                responses = schema["paths"][transition_path]["post"]["responses"]
+                self.assertTrue(expected_statuses.issubset(responses))
+                self.assertEqual(
+                    responses["400"]["content"]["application/json"]["schema"],
+                    {"$ref": "#/components/schemas/StateTransitionBadRequest"},
+                )
+
+        bad_request_variants = schema["components"]["schemas"][
+            "StateTransitionBadRequest"
+        ]["oneOf"]
+        self.assertCountEqual(
+            [variant["$ref"] for variant in bad_request_variants],
+            [
+                "#/components/schemas/StateTransitionValidationError",
+                "#/components/schemas/StateTransitionResponse",
+            ],
+        )
 
     def test_nested_states_transition_validation_map_route_is_not_available(self):
         url = f"{self.endpoint}/{self.wfr_failed.orcabus_id}/state/get_states_transition_validation_map/"
@@ -176,7 +212,6 @@ class StateViewSetTestCase(TestCase):
             "STARTING",
             "RUNNING",
             "PAUSED",
-            "CANCELLED",
         ]
         workflow_runs = []
         for index, source_status in enumerate(source_statuses):
@@ -228,6 +263,7 @@ class StateViewSetTestCase(TestCase):
             "ABORTED",
             "RESOLVED",
             "DEPRECATED",
+            "CANCELLED",
         ]
         workflow_runs = []
         for index, source_status in enumerate(source_statuses):
@@ -262,6 +298,16 @@ class StateViewSetTestCase(TestCase):
                 failure["reason"] == "INVALID_TRANSITION"
                 for failure in data["failures"]
             )
+        )
+        already_cancelled_workflow_run = workflow_runs[
+            source_statuses.index("CANCELLED")
+        ]
+        self.assertEqual(
+            State.objects.filter(
+                workflow_run=already_cancelled_workflow_run,
+                status="CANCELLED",
+            ).count(),
+            1,
         )
         mock_emit_wrsc.assert_not_called()
 

--- a/app/workflow_manager/urls/base.py
+++ b/app/workflow_manager/urls/base.py
@@ -1,5 +1,4 @@
 from django.urls import path, include
-from django.urls import path
 from drf_spectacular.views import SpectacularJSONAPIView, SpectacularSwaggerView
 
 from workflow_manager.routers import OptionalSlashDefaultRouter
@@ -12,7 +11,7 @@ from workflow_manager.viewsets.payload import PayloadViewSet
 from workflow_manager.viewsets.analysis_context import AnalysisContextViewSet
 from workflow_manager.viewsets.state import (
     StateViewSet,
-    WorkflowRunBatchStateTransitionViewSet,
+    WorkflowRunStateTransitionViewSet,
 )
 from workflow_manager.viewsets.workflow_run_action import WorkflowRunActionViewSet
 from workflow_manager.viewsets.library import LibraryViewSet
@@ -48,8 +47,8 @@ router.register(
 
 router.register(
     "workflowrun/state",
-    WorkflowRunBatchStateTransitionViewSet,
-    basename="workflowrun-state-batch-transition",
+    WorkflowRunStateTransitionViewSet,
+    basename="workflowrun-state-transition",
 )
 
 # router.register(

--- a/app/workflow_manager/viewsets/state.py
+++ b/app/workflow_manager/viewsets/state.py
@@ -1,6 +1,11 @@
 import logging
 
-from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.utils import (
+    OpenApiResponse,
+    PolymorphicProxySerializer,
+    extend_schema,
+    extend_schema_view,
+)
 from drf_spectacular.types import OpenApiTypes
 from rest_framework.decorators import action
 from rest_framework import mixins, status
@@ -19,9 +24,51 @@ from workflow_manager.serializers.state import (
     StateUpdateRequestSerializer,
     StateTransitionRequestSerializer,
     StateTransitionResponseSerializer,
+    StateTransitionValidationErrorSerializer,
 )
 
 logger = logging.getLogger(__name__)
+
+
+STATE_TRANSITION_RESPONSES = {
+    status.HTTP_201_CREATED: OpenApiResponse(
+        response=StateTransitionResponseSerializer,
+        description="Every requested workflow run was transitioned successfully.",
+    ),
+    status.HTTP_207_MULTI_STATUS: OpenApiResponse(
+        response=StateTransitionResponseSerializer,
+        description="Some workflow runs were transitioned and some failed.",
+    ),
+    status.HTTP_400_BAD_REQUEST: OpenApiResponse(
+        response=PolymorphicProxySerializer(
+            component_name="StateTransitionBadRequest",
+            serializers=[
+                StateTransitionValidationErrorSerializer,
+                StateTransitionResponseSerializer,
+            ],
+            resource_type_field_name=None,
+        ),
+        description=(
+            "The request body failed serializer validation, or every requested "
+            "transition failed because a workflow run was not found or the "
+            "transition was invalid."
+        ),
+    ),
+    status.HTTP_500_INTERNAL_SERVER_ERROR: OpenApiResponse(
+        response=StateTransitionResponseSerializer,
+        description=(
+            "No requested transition succeeded, and at least one failed during "
+            "state creation."
+        ),
+    ),
+    status.HTTP_502_BAD_GATEWAY: OpenApiResponse(
+        response=StateTransitionResponseSerializer,
+        description=(
+            "No requested transition succeeded, and at least one failed while "
+            "emitting a WRSC event."
+        ),
+    ),
+}
 
 
 class StateTransitionValidationMixin:
@@ -54,6 +101,7 @@ class StateTransitionValidationMixin:
                 "ABORTED",
                 "RESOLVED",
                 "DEPRECATED",
+                "CANCELLED",
             ]
         },
     }
@@ -388,7 +436,7 @@ class WorkflowRunStateTransitionViewSet(StateTransitionValidationMixin, GenericV
 
     @extend_schema(
         request=StateTransitionRequestSerializer,
-        responses={201: StateTransitionResponseSerializer},
+        responses=STATE_TRANSITION_RESPONSES,
         summary="Mark workflow runs as deprecated",
         description="Transition workflow runs from SUCCEEDED to DEPRECATED.",
     )
@@ -398,7 +446,7 @@ class WorkflowRunStateTransitionViewSet(StateTransitionValidationMixin, GenericV
 
     @extend_schema(
         request=StateTransitionRequestSerializer,
-        responses={201: StateTransitionResponseSerializer},
+        responses=STATE_TRANSITION_RESPONSES,
         summary="Mark workflow runs as resolved",
         description="Transition workflow runs from FAILED to RESOLVED.",
     )
@@ -408,7 +456,7 @@ class WorkflowRunStateTransitionViewSet(StateTransitionValidationMixin, GenericV
 
     @extend_schema(
         request=StateTransitionRequestSerializer,
-        responses={201: StateTransitionResponseSerializer},
+        responses=STATE_TRANSITION_RESPONSES,
         summary="Cancel workflow runs",
         description="Transition non-terminal workflow runs to CANCELLED.",
     )

--- a/app/workflow_manager/viewsets/state.py
+++ b/app/workflow_manager/viewsets/state.py
@@ -16,10 +16,9 @@ from workflow_manager_proc.services.workflow_run import (
 )
 from workflow_manager.serializers.state import (
     StateSerializer,
-    StateCreateRequestSerializer,
     StateUpdateRequestSerializer,
-    StateBatchTransitionRequestSerializer,
-    StateBatchTransitionResponseSerializer,
+    StateTransitionRequestSerializer,
+    StateTransitionResponseSerializer,
 )
 
 logger = logging.getLogger(__name__)
@@ -40,11 +39,23 @@ class StateTransitionValidationMixin:
     """
 
     states_transition_validation_map = {
-        "RESOLVED": ["FAILED"],  # Only FAILED can transition to RESOLVED, refer: https://github.com/umccr/orcabus/issues/593.
-        "DEPRECATED": ["SUCCEEDED"],  # Only SUCCEEDED to transition to DEPRECATED, refer https://github.com/OrcaBus/service-workflow-manager/issues/163.
+        "RESOLVED": [
+            "FAILED"
+        ],  # Only FAILED can transition to RESOLVED, refer: https://github.com/umccr/orcabus/issues/593.
+        "DEPRECATED": [
+            "SUCCEEDED"
+        ],  # Only SUCCEEDED to transition to DEPRECATED, refer https://github.com/OrcaBus/service-workflow-manager/issues/163.
         # Ongoing states can transition to CANCELLED, but not terminal states or RESOLVED/DEPRECATED. This is to prevent accidentally canceling completed workflow runs or those that have already been marked as resolved/deprecated.
         # refer https://github.com/OrcaBus/service-workflow-manager/pull/169.
-        "CANCELLED": {'excluded_states': ["SUCCEEDED", "FAILED", "ABORTED", "RESOLVED", "DEPRECATED"]},
+        "CANCELLED": {
+            "excluded_states": [
+                "SUCCEEDED",
+                "FAILED",
+                "ABORTED",
+                "RESOLVED",
+                "DEPRECATED",
+            ]
+        },
     }
 
     @staticmethod
@@ -146,7 +157,7 @@ class StateTransitionValidationMixin:
 
     @staticmethod
     def _failure_response_status(failures: list[dict]) -> int:
-        """Choose the most helpful HTTP status when no batch item succeeds.
+        """Choose the most helpful HTTP status when no transition succeeds.
 
         - All client-side reasons (NOT_FOUND, INVALID_TRANSITION) → 400
         - Any upstream/WRSC emission failure → 502
@@ -162,13 +173,6 @@ class StateTransitionValidationMixin:
 
 
 @extend_schema_view(
-    create=extend_schema(
-        request=StateCreateRequestSerializer,
-        responses={201: StateSerializer},
-        description=(
-            "Create a state (body: status, comment; JSON uses camelCase per API settings)."
-        ),
-    ),
     partial_update=extend_schema(
         request=StateUpdateRequestSerializer,
         responses={200: StateSerializer},
@@ -177,146 +181,19 @@ class StateTransitionValidationMixin:
 )
 class StateViewSet(
     StateTransitionValidationMixin,
-    mixins.CreateModelMixin,
     mixins.UpdateModelMixin,
     mixins.ListModelMixin,
     GenericViewSet,
 ):
+    get_success_headers = mixins.CreateModelMixin.get_success_headers
     serializer_class = StateSerializer
     search_fields = State.get_base_fields()
-    http_method_names = ["get", "post", "patch"]
+    http_method_names = ["get", "patch"]
     pagination_class = None
     lookup_value_regex = "[^/]+"  # to allow id prefix
 
     def get_queryset(self):
         return State.objects.filter(workflow_run=self.kwargs["orcabus_id"])
-
-    @extend_schema(
-        responses=OpenApiTypes.OBJECT,
-        description="Get states transition validation map",
-    )
-    @action(
-        detail=False,
-        methods=["get"],
-        url_name="get_states_transition_validation_map",
-        url_path="get_states_transition_validation_map",
-    )
-    def get_states_transition_validation_map(self, request, **kwargs):
-        """
-        Returns states transition validation map.
-        """
-        return Response(self.states_transition_validation_map)
-
-    def create(self, request, *args, **kwargs):
-        """
-        Create a custom new state for a workflow run.
-        Currently we support "Resolved", "Deprecated"
-        """
-        required_fields = {"status", "comment"}
-        provided_fields = set(request.data.keys())
-
-        if required_fields - provided_fields:
-            return Response(
-                {"detail": "status and comment fields are required."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        wfr_orcabus_id = self.kwargs.get("orcabus_id")
-        workflow_run = WorkflowRun.objects.get(orcabus_id=wfr_orcabus_id)
-
-        body = StateCreateRequestSerializer(data=request.data)
-        body.is_valid(raise_exception=True)
-        vd = body.validated_data
-        request_status = vd["status"].upper()
-        request_comment = vd["comment"]
-
-        latest_state = workflow_run.get_latest_state()
-        # Handle case when there's no latest state - only allow DEPRECATED
-        if not latest_state:
-            if request_status != "DEPRECATED":
-                logger.warning(
-                    "Manual state transition validation failed: workflow_run_id=%s requested_status=%s latest_status=None",
-                    wfr_orcabus_id,
-                    request_status,
-                )
-                return Response(
-                    {
-                        "detail": "No state found for workflow run '{}'. Only DEPRECATED is allowed when there are no states.".format(
-                            wfr_orcabus_id
-                        )
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-            latest_status = None
-        else:
-            latest_status = latest_state.status
-            # check if the state status is valid
-            if not self.is_valid_next_state(latest_status, request_status):
-                logger.warning(
-                    "Manual state transition validation failed: workflow_run_id=%s requested_status=%s latest_status=%s",
-                    wfr_orcabus_id,
-                    request_status,
-                    latest_status,
-                )
-                return Response(
-                    {
-                        "detail": "Invalid state request. Can't add state '{}' to '{}'".format(
-                            request_status, latest_status
-                        )
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-        logger.info(
-            "Manual state transition validated: workflow_run_id=%s requested_status=%s latest_status=%s",
-            wfr_orcabus_id,
-            request_status,
-            latest_status,
-        )
-
-        try:
-            with transaction.atomic():
-                instance, _ = self.create_state_and_emit_wrsc(
-                    workflow_run,
-                    request_status,
-                    request_comment,
-                )
-        except DatabaseError as exc:
-            logger.exception(
-                "Manual state transition failed during database operation and was rolled back: workflow_run_id=%s requested_status=%s",
-                wfr_orcabus_id,
-                request_status,
-            )
-            return Response(
-                {
-                    "detail": "Failed to create workflow-run state. The operation was rolled back.",
-                    "correlation_id": f"{wfr_orcabus_id}:{request_status}",
-                },
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
-        except Exception as exc:
-            logger.exception(
-                "Manual state transition failed while emitting WRSC event and was rolled back: workflow_run_id=%s requested_status=%s",
-                wfr_orcabus_id,
-                request_status,
-            )
-            return Response(
-                {
-                    "detail": "Failed to create workflow-run state and emit WRSC event. The operation was rolled back.",
-                    "correlation_id": f"{wfr_orcabus_id}:{request_status}",
-                },
-                status=status.HTTP_502_BAD_GATEWAY,
-            )
-
-        data = StateSerializer(instance).data
-        headers = self.get_success_headers(data)
-        logger.info(
-            "Manual state transition completed: workflow_run_id=%s state_id=%s status=%s",
-            wfr_orcabus_id,
-            instance.orcabus_id,
-            request_status,
-        )
-        return Response(data, status=status.HTTP_201_CREATED, headers=headers)
 
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop("partial", False)
@@ -354,27 +231,32 @@ class StateViewSet(
         return Response(data, status=status.HTTP_200_OK, headers=headers)
 
 
-@extend_schema_view(
-    batch_state_transition=extend_schema(
-        request=StateBatchTransitionRequestSerializer,
-        responses={201: StateBatchTransitionResponseSerializer},
-        description="Batch transition workflow runs to a target state.",
-    )
-)
-class WorkflowRunBatchStateTransitionViewSet(
-    StateTransitionValidationMixin, GenericViewSet
-):
-    http_method_names = ["post"]
+class WorkflowRunStateTransitionViewSet(StateTransitionValidationMixin, GenericViewSet):
+    """User-initiated workflow run state transitions for one or more runs."""
+
+    http_method_names = ["get", "post"]
     pagination_class = None
 
-    @action(detail=False, methods=["post"], url_path="batch-state-transition")
-    def batch_state_transition(self, request, *args, **kwargs):
-        body = StateBatchTransitionRequestSerializer(data=request.data)
+    @extend_schema(
+        responses=OpenApiTypes.OBJECT,
+        description="Get states transition validation map.",
+    )
+    @action(
+        detail=False,
+        methods=["get"],
+        url_name="get_states_transition_validation_map",
+        url_path="get_states_transition_validation_map",
+    )
+    def get_states_transition_validation_map(self, request, **kwargs):
+        """Return the state transition validation map."""
+        return Response(self.states_transition_validation_map)
+
+    def _state_transition(self, request, request_status: str):
+        body = StateTransitionRequestSerializer(data=request.data)
         body.is_valid(raise_exception=True)
         vd = body.validated_data
 
         workflowrun_orcabus_ids = vd["workflowrun_orcabus_ids"]
-        request_status = vd["status"].upper()
         request_comment = vd["comment"]
 
         normalized_ids = [
@@ -394,7 +276,7 @@ class WorkflowRunBatchStateTransitionViewSet(
             wfr = workflow_runs_by_normalized_id.get(normalized_id)
             if not wfr:
                 logger.warning(
-                    "Batch manual state transition skipped missing workflow run: workflow_run_id=%s requested_status=%s",
+                    "Manual state transition skipped missing workflow run: workflow_run_id=%s requested_status=%s",
                     raw_id,
                     request_status,
                 )
@@ -411,7 +293,7 @@ class WorkflowRunBatchStateTransitionViewSet(
             latest_status = latest_state.status if latest_state else None
             if not self.is_valid_next_state(latest_status, request_status):
                 logger.warning(
-                    "Batch manual state transition validation failed: workflow_run_id=%s requested_status=%s latest_status=%s",
+                    "Manual state transition validation failed: workflow_run_id=%s requested_status=%s latest_status=%s",
                     wfr.orcabus_id,
                     request_status,
                     latest_status,
@@ -430,7 +312,7 @@ class WorkflowRunBatchStateTransitionViewSet(
                 continue
 
             logger.info(
-                "Batch manual state transition validated: workflow_run_id=%s requested_status=%s latest_status=%s",
+                "Manual state transition validated: workflow_run_id=%s requested_status=%s latest_status=%s",
                 wfr.orcabus_id,
                 request_status,
                 latest_status,
@@ -442,9 +324,9 @@ class WorkflowRunBatchStateTransitionViewSet(
                         request_status,
                         request_comment,
                     )
-            except DatabaseError as exc:
+            except DatabaseError:
                 logger.exception(
-                    "Batch manual state transition failed during database operation and was rolled back: workflow_run_id=%s requested_status=%s",
+                    "Manual state transition failed during database operation and was rolled back: workflow_run_id=%s requested_status=%s",
                     wfr.orcabus_id,
                     request_status,
                 )
@@ -456,9 +338,9 @@ class WorkflowRunBatchStateTransitionViewSet(
                     }
                 )
                 continue
-            except Exception as exc:
+            except Exception:
                 logger.exception(
-                    "Batch manual state transition failed while emitting WRSC event and was rolled back: workflow_run_id=%s requested_status=%s",
+                    "Manual state transition failed while emitting WRSC event and was rolled back: workflow_run_id=%s requested_status=%s",
                     wfr.orcabus_id,
                     request_status,
                 )
@@ -473,7 +355,7 @@ class WorkflowRunBatchStateTransitionViewSet(
 
             created_workflowrun_ids.append(wfr.orcabus_id)
             logger.info(
-                "Batch manual state transition completed: workflow_run_id=%s state_id=%s status=%s",
+                "Manual state transition completed: workflow_run_id=%s state_id=%s status=%s",
                 wfr.orcabus_id,
                 state_instance.orcabus_id,
                 request_status,
@@ -487,7 +369,7 @@ class WorkflowRunBatchStateTransitionViewSet(
                 else self._failure_response_status(failures)
             )
 
-        summary = StateBatchTransitionResponseSerializer(
+        summary = StateTransitionResponseSerializer(
             instance={
                 "created_count": len(created_workflowrun_ids),
                 "workflowrun_orcabus_ids": created_workflowrun_ids,
@@ -496,10 +378,40 @@ class WorkflowRunBatchStateTransitionViewSet(
             }
         )
         logger.info(
-            "Batch manual state transition finished: requested_status=%s created_count=%s failed_count=%s response_status=%s",
+            "Manual state transition finished: requested_status=%s created_count=%s failed_count=%s response_status=%s",
             request_status,
             len(created_workflowrun_ids),
             len(failures),
             response_status,
         )
         return Response(summary.data, status=response_status)
+
+    @extend_schema(
+        request=StateTransitionRequestSerializer,
+        responses={201: StateTransitionResponseSerializer},
+        summary="Mark workflow runs as deprecated",
+        description="Transition workflow runs from SUCCEEDED to DEPRECATED.",
+    )
+    @action(detail=False, methods=["post"], url_path="deprecate")
+    def deprecate(self, request, *args, **kwargs):
+        return self._state_transition(request, "DEPRECATED")
+
+    @extend_schema(
+        request=StateTransitionRequestSerializer,
+        responses={201: StateTransitionResponseSerializer},
+        summary="Mark workflow runs as resolved",
+        description="Transition workflow runs from FAILED to RESOLVED.",
+    )
+    @action(detail=False, methods=["post"], url_path="resolve")
+    def resolve(self, request, *args, **kwargs):
+        return self._state_transition(request, "RESOLVED")
+
+    @extend_schema(
+        request=StateTransitionRequestSerializer,
+        responses={201: StateTransitionResponseSerializer},
+        summary="Cancel workflow runs",
+        description="Transition non-terminal workflow runs to CANCELLED.",
+    )
+    @action(detail=False, methods=["post"], url_path="cancel")
+    def cancel(self, request, *args, **kwargs):
+        return self._state_transition(request, "CANCELLED")

--- a/bin/deploy.ts
+++ b/bin/deploy.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { StatelessStack } from '../infrastructure/toolchain/stateless-stack';
 import { TOOLCHAIN_ENVIRONMENT } from '@orcabus/platform-cdk-constructs/deployment-stack-pipeline';

--- a/infrastructure/stage/stack.ts
+++ b/infrastructure/stage/stack.ts
@@ -200,7 +200,7 @@ export class WorkflowManagerStack extends GitStack {
       integration: apiIntegration,
       authorizer: wfmApi.authStackHttpLambdaAuthorizer,
       routeKey: HttpRouteKey.with(
-        `/api/${API_VERSION}/workflowrun/state/deprecate`,
+        `/api/${API_VERSION}/workflowrun/state/deprecate/`,
         HttpMethod.POST
       ),
     });
@@ -208,7 +208,10 @@ export class WorkflowManagerStack extends GitStack {
       httpApi: httpApi,
       integration: apiIntegration,
       authorizer: wfmApi.authStackHttpLambdaAuthorizer,
-      routeKey: HttpRouteKey.with(`/api/${API_VERSION}/workflowrun/state/resolve`, HttpMethod.POST),
+      routeKey: HttpRouteKey.with(
+        `/api/${API_VERSION}/workflowrun/state/resolve/`,
+        HttpMethod.POST
+      ),
     });
   }
 

--- a/infrastructure/stage/stack.ts
+++ b/infrastructure/stage/stack.ts
@@ -195,6 +195,21 @@ export class WorkflowManagerStack extends GitStack {
         HttpMethod.POST
       ),
     });
+    new HttpRoute(this, 'PostManualStateTransitionHttpRoute', {
+      httpApi: httpApi,
+      integration: apiIntegration,
+      authorizer: wfmApi.authStackHttpLambdaAuthorizer,
+      routeKey: HttpRouteKey.with(
+        `/api/${API_VERSION}/workflowrun/state/deprecate`,
+        HttpMethod.POST
+      ),
+    });
+    new HttpRoute(this, 'PostManualStateTransitionHttpRoute2', {
+      httpApi: httpApi,
+      integration: apiIntegration,
+      authorizer: wfmApi.authStackHttpLambdaAuthorizer,
+      routeKey: HttpRouteKey.with(`/api/${API_VERSION}/workflowrun/state/resolve`, HttpMethod.POST),
+    });
   }
 
   private createWruEventHandler() {

--- a/infrastructure/stage/stack.ts
+++ b/infrastructure/stage/stack.ts
@@ -195,21 +195,21 @@ export class WorkflowManagerStack extends GitStack {
         HttpMethod.POST
       ),
     });
-    new HttpRoute(this, 'PostManualStateTransitionHttpRoute', {
+    new HttpRoute(this, 'PostDeprecateStateTransitionHttpRoute', {
       httpApi: httpApi,
       integration: apiIntegration,
       authorizer: wfmApi.authStackHttpLambdaAuthorizer,
       routeKey: HttpRouteKey.with(
-        `/api/${API_VERSION}/workflowrun/state/deprecate/`,
+        `/api/${API_VERSION}/workflowrun/state/deprecate/{proxy+}`,
         HttpMethod.POST
       ),
     });
-    new HttpRoute(this, 'PostManualStateTransitionHttpRoute2', {
+    new HttpRoute(this, 'PostResolveStateTransitionHttpRoute', {
       httpApi: httpApi,
       integration: apiIntegration,
       authorizer: wfmApi.authStackHttpLambdaAuthorizer,
       routeKey: HttpRouteKey.with(
-        `/api/${API_VERSION}/workflowrun/state/resolve/`,
+        `/api/${API_VERSION}/workflowrun/state/resolve/{proxy+}`,
         HttpMethod.POST
       ),
     });

--- a/package.json
+++ b/package.json
@@ -23,22 +23,22 @@
     "@eslint/js": "^10.0.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.9.3",
-    "aws-cdk": "^2.1126.0",
+    "aws-cdk": "^2.1135.0",
     "cdk-nag": "^2.38.2",
-    "eslint": "^10.5.0",
-    "globals": "^17.6.0",
+    "eslint": "^10.8.1",
+    "globals": "^17.9.0",
     "jest": "^30.4.2",
-    "prettier": "^3.8.4",
+    "prettier": "^3.9.6",
     "test-js": "^0.0.4",
-    "ts-jest": "^29.4.11",
+    "ts-jest": "^29.4.12",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3",
-    "typescript-eslint": "^8.61.0"
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.66.0"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.259.0-alpha.0",
-    "@orcabus/platform-cdk-constructs": "1.7.1",
-    "aws-cdk-lib": "^2.259.0",
-    "constructs": "^10.6.0"
+    "@aws-cdk/aws-lambda-python-alpha": "2.263.0-alpha.0",
+    "@orcabus/platform-cdk-constructs": "1.8.0",
+    "aws-cdk-lib": "^2.263.0",
+    "constructs": "^10.8.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,34 +4,26 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  brace-expansion@<5.0.6: '>=5.0.6'
-  flatted@<=3.4.1: '>=3.4.2'
-  handlebars@>=4.0.0 <4.7.9: '>=4.7.9'
-  js-yaml@<=4.1.1: ^4.1.2
-  minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
-  picomatch@<4.0.4: '>=4.0.4'
-
 importers:
 
   .:
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha':
-        specifier: 2.259.0-alpha.0
-        version: 2.259.0-alpha.0(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 2.263.0-alpha.0
+        version: 2.263.0-alpha.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1)
       '@orcabus/platform-cdk-constructs':
-        specifier: 1.7.1
-        version: 1.7.1(@aws-cdk/aws-lambda-python-alpha@2.259.0-alpha.0(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 1.8.0
+        version: 1.8.0(@aws-cdk/aws-lambda-python-alpha@2.263.0-alpha.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1))(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1)
       aws-cdk-lib:
-        specifier: ^2.259.0
-        version: 2.259.0(constructs@10.6.0)
+        specifier: ^2.263.0
+        version: 2.263.0(constructs@10.8.1)
       constructs:
-        specifier: ^10.6.0
-        version: 10.6.0
+        specifier: ^10.8.1
+        version: 10.8.1
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.5.0)
+        version: 10.0.1(eslint@10.8.1)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -39,38 +31,38 @@ importers:
         specifier: ^25.9.3
         version: 25.9.3
       aws-cdk:
-        specifier: ^2.1126.0
-        version: 2.1126.0
+        specifier: ^2.1135.0
+        version: 2.1135.1
       cdk-nag:
         specifier: ^2.38.2
-        version: 2.38.2(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0)
+        version: 2.38.2(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1)
       eslint:
-        specifier: ^10.5.0
-        version: 10.5.0
+        specifier: ^10.8.1
+        version: 10.8.1
       globals:
-        specifier: ^17.6.0
-        version: 17.6.0
+        specifier: ^17.9.0
+        version: 17.9.0
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
+        version: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3))
       prettier:
-        specifier: ^3.8.4
-        version: 3.8.4
+        specifier: ^3.9.6
+        version: 3.9.6
       test-js:
         specifier: ^0.0.4
         version: 0.0.4
       ts-jest:
-        specifier: ^29.4.11
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)))(typescript@5.9.3)
+        specifier: ^29.4.12
+        version: 29.4.12(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3)))(typescript@6.0.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.9.3)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.9.3)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       typescript-eslint:
-        specifier: ^8.61.0
-        version: 8.61.0(eslint@10.5.0)(typescript@5.9.3)
+        specifier: ^8.66.0
+        version: 8.66.0(eslint@10.8.1)(typescript@6.0.3)
 
 packages:
 
@@ -80,15 +72,15 @@ packages:
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
     resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==}
 
-  '@aws-cdk/aws-lambda-python-alpha@2.259.0-alpha.0':
-    resolution: {integrity: sha512-J7TK7RMHIy2zBEJcS0cJFja4f24i1uwbgiCxXQmOKFxiBuPaSzpiSY5HkJEbm5B7PquOIHNnvzzo8YAkwITg2g==}
+  '@aws-cdk/aws-lambda-python-alpha@2.263.0-alpha.0':
+    resolution: {integrity: sha512-1OgLG7TGGH5/Wt7firHTOFyxU6ymZNaANELq62h1yNfTBOSNsNhdzkWLYxhoXDPBvNndEsmUnKVCij7U+dXsqQ==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
-      aws-cdk-lib: ^2.259.0
+      aws-cdk-lib: ^2.263.0
       constructs: ^10.5.0
 
-  '@aws-cdk/cloud-assembly-schema@54.2.0':
-    resolution: {integrity: sha512-u3lFXmiXSBozxGBmKTCVD/2mTDsaXzLZH3KYiIQKcB+zPldXOeE5TnooBgKV9ih2jVTo8ML0HpkhfAq2eiv0eQ==}
+  '@aws-cdk/cloud-assembly-schema@54.17.0':
+    resolution: {integrity: sha512-wV1GmMM5AvDkiJIenb9aJcBiGTa5KwX/C/mIjFZCsWsB5b1rEMLnwMageqrOpL2mWKicpxqS8ofF/Yte4Lm3Dg==}
     engines: {node: '>= 18.0.0'}
     bundledDependencies:
       - jsonschema
@@ -286,8 +278,8 @@ packages:
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.6.0':
-    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/core@1.2.1':
@@ -450,8 +442,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@orcabus/platform-cdk-constructs@1.7.1':
-    resolution: {integrity: sha512-9/jesp4Y2RVJJ/kcjk3afJlooVNmnNxSGLfRCQcFJDhjp4UGY3/wbNaHxpEpPRV9bw145V12Pt0+0zvHe5NouQ==}
+  '@orcabus/platform-cdk-constructs@1.8.0':
+    resolution: {integrity: sha512-hSwpr/KJKJGKzJ3j0IJ96pHuwLJ6+u6DmCiVvvvUWCTvPmOiIZv15yGRJZP1qK4tXvescVw9ke0iqoAUKrkn5A==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.244.0-alpha.0
       aws-cdk-lib: ^2.244.0
@@ -534,63 +526,63 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@typescript-eslint/eslint-plugin@8.61.0':
-    resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
+  '@typescript-eslint/eslint-plugin@8.66.0':
+    resolution: {integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.61.0
+      '@typescript-eslint/parser': ^8.66.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.61.0':
-    resolution: {integrity: sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.61.0':
-    resolution: {integrity: sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.61.0':
-    resolution: {integrity: sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.61.0':
-    resolution: {integrity: sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.61.0':
-    resolution: {integrity: sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==}
+  '@typescript-eslint/parser@8.66.0':
+    resolution: {integrity: sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.61.0':
-    resolution: {integrity: sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.61.0':
-    resolution: {integrity: sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==}
+  '@typescript-eslint/project-service@8.66.0':
+    resolution: {integrity: sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.61.0':
-    resolution: {integrity: sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==}
+  '@typescript-eslint/scope-manager@8.66.0':
+    resolution: {integrity: sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.66.0':
+    resolution: {integrity: sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.66.0':
+    resolution: {integrity: sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.61.0':
-    resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
+  '@typescript-eslint/types@8.66.0':
+    resolution: {integrity: sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.66.0':
+    resolution: {integrity: sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.66.0':
+    resolution: {integrity: sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.66.0':
+    resolution: {integrity: sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.1':
@@ -764,15 +756,16 @@ packages:
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
-  argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
-  aws-cdk-lib@2.259.0:
-    resolution: {integrity: sha512-qcsbyRBZpFMUzx/Nle5vKXFC14Z1VutvAqw6S4Duh3Yj5ZFl4e/RhN2Vg8QmYktxu9l1aF9H5UyF+Xz81qk9gw==}
+  aws-cdk-lib@2.263.0:
+    resolution: {integrity: sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
       constructs: ^10.5.0
     bundledDependencies:
+      - '@aws/cloudformation-validate'
       - '@balena/dockerignore'
       - '@aws-cdk/cloud-assembly-api'
       - case
@@ -782,12 +775,11 @@ packages:
       - minimatch
       - punycode
       - semver
-      - table
       - yaml
       - mime-types
 
-  aws-cdk@2.1126.0:
-    resolution: {integrity: sha512-uNoocb3vCPiAT3j9+SwL6pn/VVggHWBsgC2XpxyhNvYQYt6cE9BM/149GWwtdcwnLrPjnwW1+CV/5nSSh5dV+w==}
+  aws-cdk@2.1135.1:
+    resolution: {integrity: sha512-g1jcMfWlyYtGamFJ/kPBOCuchl3NfwTF2UwOLTIDN0nJbGm84EAO+c8DlYnaemM8UmKFkdoq4BGdmiNL5nHWwA==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
 
@@ -816,6 +808,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.11.0 || ^8.0.0-beta.1
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -825,9 +820,15 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -899,8 +900,11 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  constructs@10.6.0:
-    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==}
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  constructs@10.8.1:
+    resolution: {integrity: sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -987,8 +991,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.5.0:
-    resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
+  eslint@10.8.1:
+    resolution: {integrity: sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1000,6 +1004,11 @@ packages:
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -1045,7 +1054,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: '>=4.0.4'
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1110,8 +1119,8 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  globals@17.6.0:
-    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
+  globals@17.9.0:
+    resolution: {integrity: sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==}
     engines: {node: '>=18'}
 
   graceful-fs@4.2.11:
@@ -1337,8 +1346,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1515,6 +1524,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -1531,8 +1544,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1574,6 +1587,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1599,6 +1617,9 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -1668,8 +1689,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-jest@29.4.11:
-    resolution: {integrity: sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==}
+  ts-jest@29.4.12:
+    resolution: {integrity: sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -1728,15 +1749,15 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  typescript-eslint@8.61.0:
-    resolution: {integrity: sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==}
+  typescript-eslint@8.66.0:
+    resolution: {integrity: sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1826,12 +1847,12 @@ snapshots:
 
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
 
-  '@aws-cdk/aws-lambda-python-alpha@2.259.0-alpha.0(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0)':
+  '@aws-cdk/aws-lambda-python-alpha@2.263.0-alpha.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1)':
     dependencies:
-      aws-cdk-lib: 2.259.0(constructs@10.6.0)
-      constructs: 10.6.0
+      aws-cdk-lib: 2.263.0(constructs@10.8.1)
+      constructs: 10.8.1
 
-  '@aws-cdk/cloud-assembly-schema@54.2.0': {}
+  '@aws-cdk/cloud-assembly-schema@54.17.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -2042,9 +2063,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.1)':
     dependencies:
-      eslint: 10.5.0
+      eslint: 10.8.1
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -2057,7 +2078,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.6.0':
+  '@eslint/config-helpers@0.7.0':
     dependencies:
       '@eslint/core': 1.2.1
 
@@ -2065,9 +2086,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.5.0)':
+  '@eslint/js@10.0.1(eslint@10.8.1)':
     optionalDependencies:
-      eslint: 10.5.0
+      eslint: 10.8.1
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -2106,7 +2127,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.2.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -2120,7 +2141,7 @@ snapshots:
       jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.4.2(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))':
+  '@jest/core@30.4.2(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.4.1
       '@jest/pattern': 30.4.0
@@ -2136,7 +2157,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
+      jest-config: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3))
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
@@ -2320,11 +2341,11 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@orcabus/platform-cdk-constructs@1.7.1(@aws-cdk/aws-lambda-python-alpha@2.259.0-alpha.0(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0)':
+  '@orcabus/platform-cdk-constructs@1.8.0(@aws-cdk/aws-lambda-python-alpha@2.263.0-alpha.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1))(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1)':
     dependencies:
-      '@aws-cdk/aws-lambda-python-alpha': 2.259.0-alpha.0(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0)
-      aws-cdk-lib: 2.259.0(constructs@10.6.0)
-      constructs: 10.6.0
+      '@aws-cdk/aws-lambda-python-alpha': 2.263.0-alpha.0(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1)
+      aws-cdk-lib: 2.263.0(constructs@10.8.1)
+      constructs: 10.8.1
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -2408,95 +2429,95 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1)(typescript@6.0.3))(eslint@10.8.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.61.0
-      eslint: 10.5.0
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.66.0
+      eslint: 10.8.1
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.66.0(eslint@10.8.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.61.0
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.66.0
       debug: 4.4.3
-      eslint: 10.5.0
-      typescript: 5.9.3
+      eslint: 10.8.1
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.61.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.66.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.66.0
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.61.0':
+  '@typescript-eslint/scope-manager@8.66.0':
     dependencies:
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/visitor-keys': 8.61.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/visitor-keys': 8.66.0
 
-  '@typescript-eslint/tsconfig-utils@8.61.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.66.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.61.0(eslint@10.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.1)(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.5.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      eslint: 10.8.1
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.61.0': {}
+  '@typescript-eslint/types@8.66.0': {}
 
-  '@typescript-eslint/typescript-estree@8.61.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.66.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.61.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/visitor-keys': 8.61.0
+      '@typescript-eslint/project-service': 8.66.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/visitor-keys': 8.66.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.4
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.0(eslint@10.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.66.0(eslint@10.8.1)(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
-      eslint: 10.5.0
-      typescript: 5.9.3
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1)
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@6.0.3)
+      eslint: 10.8.1
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.61.0':
+  '@typescript-eslint/visitor-keys@8.66.0':
     dependencies:
-      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/types': 8.66.0
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.1': {}
@@ -2607,20 +2628,22 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 4.0.4
+      picomatch: 2.3.2
 
   arg@4.1.3: {}
 
-  argparse@2.0.1: {}
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
-  aws-cdk-lib@2.259.0(constructs@10.6.0):
+  aws-cdk-lib@2.263.0(constructs@10.8.1):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.282
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
-      '@aws-cdk/cloud-assembly-schema': 54.2.0
-      constructs: 10.6.0
+      '@aws-cdk/cloud-assembly-schema': 54.17.0
+      constructs: 10.8.1
 
-  aws-cdk@2.1126.0: {}
+  aws-cdk@2.1135.1: {}
 
   babel-jest@30.4.1(@babel/core@7.29.7):
     dependencies:
@@ -2674,11 +2697,22 @@ snapshots:
       babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.37: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2708,10 +2742,10 @@ snapshots:
 
   caniuse-lite@1.0.30001799: {}
 
-  cdk-nag@2.38.2(aws-cdk-lib@2.259.0(constructs@10.6.0))(constructs@10.6.0):
+  cdk-nag@2.38.2(aws-cdk-lib@2.263.0(constructs@10.8.1))(constructs@10.8.1):
     dependencies:
-      aws-cdk-lib: 2.259.0(constructs@10.6.0)
-      constructs: 10.6.0
+      aws-cdk-lib: 2.263.0(constructs@10.8.1)
+      constructs: 10.8.1
 
   chalk@4.1.2:
     dependencies:
@@ -2740,7 +2774,9 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  constructs@10.6.0: {}
+  concat-map@0.0.1: {}
+
+  constructs@10.8.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -2797,12 +2833,12 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.5.0:
+  eslint@10.8.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
+      '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@humanfs/node': 0.16.8
@@ -2837,6 +2873,8 @@ snapshots:
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
+
+  esprima@4.0.1: {}
 
   esquery@1.7.0:
     dependencies:
@@ -2948,7 +2986,7 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  globals@17.6.0: {}
+  globals@17.9.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -3070,15 +3108,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)):
+  jest-cli@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
+      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3))
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
+      jest-config: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3))
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.2
@@ -3089,7 +3127,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)):
+  jest-config@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/get-type': 30.1.0
@@ -3116,7 +3154,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.9.3
-      ts-node: 10.9.2(@types/node@25.9.3)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@25.9.3)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -3337,12 +3375,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)):
+  jest@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
+      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3))
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
+      jest-cli: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -3352,9 +3390,10 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@3.15.1:
     dependencies:
-      argparse: 2.0.1
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   jsesc@3.1.0: {}
 
@@ -3413,15 +3452,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -3502,6 +3541,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
@@ -3512,7 +3553,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.4: {}
+  prettier@3.9.6: {}
 
   pretty-format@30.4.1:
     dependencies:
@@ -3541,6 +3582,8 @@ snapshots:
 
   semver@7.8.4: {}
 
+  semver@7.8.5: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -3559,6 +3602,8 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
     dependencies:
@@ -3622,22 +3667,22 @@ snapshots:
 
   tmpl@1.0.5: {}
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.12(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3))
+      jest: 30.4.2(@types/node@25.9.3)(ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.8.4
+      semver: 7.8.5
       type-fest: 4.41.0
-      typescript: 5.9.3
+      typescript: 6.0.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.7
@@ -3646,7 +3691,7 @@ snapshots:
       babel-jest: 30.4.1(@babel/core@7.29.7)
       jest-util: 30.4.1
 
-  ts-node@10.9.2(@types/node@25.9.3)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -3660,7 +3705,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -3677,18 +3722,18 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  typescript-eslint@8.61.0(eslint@10.5.0)(typescript@5.9.3):
+  typescript-eslint@8.66.0(eslint@10.8.1)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0)(typescript@5.9.3)
-      eslint: 10.5.0
-      typescript: 5.9.3
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1)(typescript@6.0.3))(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.1)(typescript@6.0.3)
+      eslint: 10.8.1
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  unrs-resolver: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,0 @@
-allowBuilds:
-  unrs-resolver: false
-
-onlyBuiltDependencies:
-  - unrs-resolver

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,16 +1,5 @@
 allowBuilds:
   unrs-resolver: false
 
-minimumReleaseAgeExclude:
-  - js-yaml@4.1.2
-
 onlyBuiltDependencies:
   - unrs-resolver
-
-overrides:
-  brace-expansion@<5.0.6: '>=5.0.6'
-  flatted@<=3.4.1: '>=3.4.2'
-  handlebars@>=4.0.0 <4.7.9: '>=4.7.9'
-  js-yaml@<=4.1.1: ^4.1.2
-  minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
-  picomatch@<4.0.4: '>=4.0.4'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,10 @@
     "lib": [
       "es2020"
     ],
+    "types": [
+      "node",
+      "jest"
+    ],
     "declaration": true,
     "esModuleInterop": true,
     "strict": true,
@@ -22,9 +26,6 @@
     "experimentalDecorators": true,
     "resolveJsonModule": true,
     "strictPropertyInitialization": false,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
     "skipLibCheck": true
   },
   "exclude": [


### PR DESCRIPTION
## Summary

Resolve https://github.com/OrcaBus/service-workflow-manager/issues/175,
Couple with RP: https://github.com/OrcaBus/service-shared-resources/pull/26 for verified permission.

This PR replaces the generic workflow-run state creation APIs with dedicated action endpoints for deprecating, resolving, and cancelling one or more workflow runs.

The target state is determined by the endpoint instead of a client-supplied `status`. This simplifies authorization with AWS Verified Permissions because permissions no longer depend on inspecting the request payload.

## API Changes

### New Endpoints

```http
POST /api/v1/workflowrun/state/deprecate
POST /api/v1/workflowrun/state/resolve
POST /api/v1/workflowrun/state/cancel
```

All three endpoints accept the following request body:

```json
{
  "workflowrunOrcabusIds": [
    "wfr.xxxxxxxxx",
    "wfr.yyyyyyyyy"
  ],
  "comment": "Reason for the transition"
}
```

Each endpoint supports one or more workflow-run OrcaBus IDs.

### Validation Map Endpoint

The validation-map endpoint has moved so that it no longer requires a workflow-run ID:

```http
GET /api/v1/workflowrun/state/get_states_transition_validation_map/
```

### Removed Endpoints

The following endpoints are no longer available:

```http
POST /api/v1/workflowrun/{orcabusId}/state/
POST /api/v1/workflowrun/state/batch-state-transition/
GET  /api/v1/workflowrun/{orcabusId}/state/get_states_transition_validation_map/
```

## Transition Rules

Existing state-transition rules are preserved:

| Target state | Allowed source state |
|---|---|
| `DEPRECATED` | `SUCCEEDED` |
| `RESOLVED` | `FAILED` |
| `CANCELLED` | Supported non-terminal states |

Existing no-state and excluded-state behaviour remains unchanged.

## State Creation and WRSC Events

The existing state creation and WRSC event flow remains intact:

- Each workflow run is validated independently.
- Each state is created inside an atomic transaction.
- `create_state_and_emit_wrsc` is called for every successful transition.
- If WRSC emission fails, the newly created state is rolled back.
- A failure for one workflow run does not prevent other workflow runs from being processed.
- Existing partial-success responses and failure reasons are preserved.

## Response Example

```json
{
  "createdCount": 1,
  "workflowrunOrcabusIds": [
    "wfr.xxxxxxxxx"
  ],
  "failedCount": 1,
  "failures": [
    {
      "workflowrunOrcabusId": "wfr.yyyyyyyyy",
      "reason": "INVALID_TRANSITION",
      "detail": "Invalid state transition."
    }
  ]
}
```

## Response Statuses

| Status | Description |
|---|---|
| `201 Created` | All requested transitions succeeded |
| `207 Multi-Status` | Some transitions succeeded and some failed |
| `400 Bad Request` | All failures were caused by missing workflow runs or invalid transitions |
| `500 Internal Server Error` | State creation failed |
| `502 Bad Gateway` | WRSC event emission failed |
